### PR TITLE
for rust codegen, derive(Default) is the default unless disabled

### DIFF
--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weld-codegen"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2018"
 authors = [ "wasmcloud Team" ]
 license = "Apache-2.0"

--- a/codegen/src/codegen_rust.rs
+++ b/codegen/src/codegen_rust.rs
@@ -582,7 +582,7 @@ impl<'model> RustCodeGen<'model> {
             if let Some(cg) = get_trait::<CodegenRust>(traits, codegen_rust_trait())? {
                 cg.derive_default
             } else {
-                false
+                true
             };
         w.write(b"#[derive(");
         if derive_default {


### PR DESCRIPTION
derive(Default) is enabled by default for structures
bump crate version to 0.1.6

Signed-off-by: steve <dev@somecool.net>