### PR TITLE
apply derive(Default) to all structures in core models

### DIFF
--- a/rpc-rs/Cargo.toml
+++ b/rpc-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmbus-rpc"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2018"
 authors = [ "wasmcloud Team" ]
 license = "Apache-2.0"

--- a/rpc-rs/src/wasmbus_core.rs
+++ b/rpc-rs/src/wasmbus_core.rs
@@ -39,8 +39,6 @@ pub struct HostData {
     pub env_values: HostEnvValues,
     #[serde(default)]
     pub host_id: String,
-    /// private key the provider should use to sign invocations
-    /// this field is sensitive and should never be logged
     #[serde(default)]
     pub invocation_seed: String,
     #[serde(default)]
@@ -93,7 +91,7 @@ pub struct InvocationResponse {
     pub msg: Vec<u8>,
 }
 
-/// Link definition for an actor
+/// Link definition for binding actor to provider
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct LinkDefinition {
     /// actor public key

--- a/rpc-rs/src/wasmbus_model.rs
+++ b/rpc-rs/src/wasmbus_model.rs
@@ -36,7 +36,9 @@ pub type U8 = i8;
 /// Rust codegen traits
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct CodegenRust {
-    /// Instructs rust codegen to add `#[derive(Default)]` (default false)
+    /// Instructs rust codegen to add `#[derive(Default)]`
+    /// If the codegenRust trait is not applied to a structure,
+    /// 'Default' is generated for that structure.
     #[serde(rename = "deriveDefault")]
     #[serde(default)]
     pub derive_default: bool,
@@ -87,5 +89,5 @@ pub struct Wasmbus {
 
 /// data sent via wasmbus
 /// This trait is required for all messages sent via wasmbus
-#[derive(Default, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct WasmbusData {}


### PR DESCRIPTION
use re-generated core model files, applying derive(Default) to all structures.
bump  crate version to 0.2.2

Signed-off-by: steve <dev@somecool.net>