### PR TITLE
codegen: do not derive Default for traits (but still enable deriveDefault for structures)

### DIFF
--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weld-codegen"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2018"
 authors = [ "wasmcloud Team" ]
 license = "Apache-2.0"

--- a/codegen/src/codegen_rust.rs
+++ b/codegen/src/codegen_rust.rs
@@ -582,7 +582,7 @@ impl<'model> RustCodeGen<'model> {
             if let Some(cg) = get_trait::<CodegenRust>(traits, codegen_rust_trait())? {
                 cg.derive_default
             } else {
-                true
+                !is_trait_struct // default to true for all non-trait structures
             };
         w.write(b"#[derive(");
         if derive_default {

--- a/codegen/src/gen.rs
+++ b/codegen/src/gen.rs
@@ -427,7 +427,7 @@ pub trait SourceFormatter {
 }
 
 /// confirm all files are present, otherwise return error
-fn ensure_files_exist(source_files: &Vec<std::path::PathBuf>) -> Result<()> {
+fn ensure_files_exist(source_files: &[std::path::PathBuf]) -> Result<()> {
     let missing = source_files
         .iter()
         .filter(|p| !p.is_file())


### PR DESCRIPTION
bump codegen crate to 0.1.7

Signed-off-by: steve <dev@somecool.net>