### PR TITLE
Api cleanup & a bundle of minor simplifications

### DIFF
--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weld-codegen"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2018"
 authors = [ "wasmcloud Team" ]
 license = "Apache-2.0"

--- a/codegen/src/codegen_go.rs
+++ b/codegen/src/codegen_go.rs
@@ -715,8 +715,8 @@ impl<'model> GoCodeGen<'model> {
             br#"{
             async fn dispatch(
                 &self,
-                ctx: &context::Context<'_>,
-                message: &Message<'_> ) -> Result< Message<'_>, RpcError> {
+                ctx: &Context,
+                message: &Message<'_> ) -> RpcResult< Message<'_>> {
                 match message.method {
         "#,
         );

--- a/codegen/templates/rust/rust.actor.rs.hbs
+++ b/codegen/templates/rust/rust.actor.rs.hbs
@@ -12,7 +12,7 @@ struct {{ to_pascal_case project_name }}Actor {}
 impl HttpServer for {{ to_pascal_case project_name }}Actor {
     async fn handle_request(
         &self,
-        _ctx: &context::Context<'_>,
+        _ctx: &Context,
         value: &HttpRequest,
     ) -> std::result::Result<HttpResponse, RpcError> {
         console_log("hello world");
@@ -36,7 +36,7 @@ impl HttpServer for {{ to_pascal_case project_name }}Actor {
 impl Actor for {{ to_pascal_case project_name }}Actor {
     async fn health_request(
         &self,
-        _ctx: &context::Context<'_>,
+        _ctx: &Context,
         _value: &HealthCheckRequest,
     ) -> std::result::Result<HealthCheckResponse, RpcError> {
         Ok(HealthCheckResponse {

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmbus-macros"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2018"
 authors = [ "wasmcloud Team" ]
 license = "Apache-2.0"

--- a/rpc-rs/Cargo.toml
+++ b/rpc-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmbus-rpc"
-version = "0.2.4"
+version = "0.3.0"
 edition = "2018"
 authors = [ "wasmcloud Team" ]
 license = "Apache-2.0"

--- a/rpc-rs/src/provider_main.rs
+++ b/rpc-rs/src/provider_main.rs
@@ -53,6 +53,8 @@ where
 
     // get lattice configuration from host
     let host_data = load_host_data()?;
+    eprintln!("dumping host data: {:?}", &host_data);
+
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
     eprintln!(
         "Starting HttpServer Capability Provider {} with nats url {}",

--- a/rpc-rs/src/rpc_client.rs
+++ b/rpc-rs/src/rpc_client.rs
@@ -140,8 +140,8 @@ impl RpcClient {
         Target: Into<WasmCloudEntity>,
     {
         let msg = JsonMessage(method, data).try_into()?;
-        let ir = self.send(origin, target, msg).await?;
-        let resp = response_to_json::<Resp>(&ir.msg)?;
+        let bytes = self.send(origin, target, msg).await?;
+        let resp = response_to_json::<Resp>(&bytes)?;
         Ok(resp)
     }
 
@@ -153,7 +153,7 @@ impl RpcClient {
         origin: WasmCloudEntity,
         target: Target,
         message: Message<'_>,
-    ) -> Result<InvocationResponse, RpcError>
+    ) -> Result<Vec<u8>, RpcError>
     where
         Target: Into<WasmCloudEntity>,
     {
@@ -196,7 +196,7 @@ impl RpcClient {
         match inv_response.error {
             None => {
                 trace!("rpc ok response from {}", &target_url);
-                Ok(inv_response)
+                Ok(inv_response.msg)
             }
             Some(err) => {
                 // if error is Some(_), we must ignore the msg field
@@ -335,8 +335,8 @@ impl RpcClientSync {
         Target: Into<WasmCloudEntity>,
     {
         let msg = JsonMessage(method, data).try_into()?;
-        let ir = self.send(origin, target, msg)?;
-        let resp = response_to_json::<Resp>(&ir.msg)?;
+        let bytes = self.send(origin, target, msg)?;
+        let resp = response_to_json::<Resp>(&bytes)?;
         Ok(resp)
     }
 
@@ -347,7 +347,7 @@ impl RpcClientSync {
         origin: WasmCloudEntity,
         target: Target,
         message: Message<'_>,
-    ) -> Result<InvocationResponse, RpcError>
+    ) -> Result<Vec<u8>, RpcError>
     where
         Target: Into<WasmCloudEntity>,
     {

--- a/rpc-rs/src/wasmbus_model.rs
+++ b/rpc-rs/src/wasmbus_model.rs
@@ -21,6 +21,9 @@ pub type I64 = i64;
 /// signed byte
 pub type I8 = i8;
 
+/// list of identifiers
+pub type IdentifierList = Vec<String>;
+
 /// unsigned 16-bit int
 pub type U16 = i16;
 
@@ -42,6 +45,13 @@ pub struct CodegenRust {
     #[serde(rename = "deriveDefault")]
     #[serde(default)]
     pub derive_default: bool,
+}
+
+/// indicates that a trait or class extends one or more bases
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Extends {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base: Option<IdentifierList>,
 }
 
 /// A non-empty string (minimum length 1)


### PR DESCRIPTION
- add derive macro for Health check response,
  so actors don't need to implement their own.
- remove lifetime annotation on Context
  (from `Context<'_>` to `Context`). Potential future disadvantage
  if we need to store borrowed things in Context,
  but it isn't needed for now. 
- you can now use RpcResult<T> instead of Result<T,RpcError>
- for trait functions that used to take &String
  (the input of an operation was String), you can now
  pass String, &String, or &str - (any ToString).
  For example, you can now call `keyvalue.get("name")`
  instead of `keyvalue.get("name".to_string())`.
  This simplifies the code of actors calling providers,
  but adds a bit of extra syntax for provider implementors.
- renamed SendConfig to SendOpts and made it an Option(al)
  parameter, so usually you can just pass None instead of
  constructing it.
- moved the target of the operation out of SendOpts
  into Transport, which makes Transport much more versatile,
  as it can now work for rpc over nats.

Signed-off-by: steve <dev@somecool.net>