### PR TITLE
wasmbus-macros: add capability provider derive macro

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmbus-macros"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2018"
 authors = [ "wasmcloud Team" ]
 license = "Apache-2.0"


### PR DESCRIPTION
derive macro for MessageDispatch;
remove 'legacy' handling of message names without service/trait prefix; 
bump macros crate to 0.1.5

Signed-off-by: stevelr <steve@cosmonic.com>