### PR TITLE
Fixing transport for actor to actor calls

### DIFF
--- a/rpc-rs/Cargo.toml
+++ b/rpc-rs/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "wasmbus-rpc"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2018"
 authors = [ "wasmcloud Team" ]
 license = "Apache-2.0"
 description = "Runtime library for actors and capability providers"
 homepage = "https://github.com/wasmcloud/weld"
 repository = "https://github.com/wasmcloud/weld"
-documentation = "https://docs.rs/wasmcloud-weld-rpc"
+documentation = "https://docs.rs/wasmbus-rpc"
 readme = "README.md"
 resolver = "2"
 

--- a/rpc-rs/src/actor_wasm.rs
+++ b/rpc-rs/src/actor_wasm.rs
@@ -97,12 +97,17 @@ impl Transport for WasmHost {
         req: Message<'_>,
         _opts: Option<crate::SendOpts>,
     ) -> std::result::Result<Vec<u8>, RpcError> {
-        let res = host_call(
-            &self.target.link_name,
-            &self.target.contract_id,
-            req.method,
-            req.arg.as_ref(),
-        )?;
+        let res = if !self.target.public_key.is_empty() {
+            // actor-to-actor calls use namespace for the actor target identifier
+            host_call("", &self.target.public_key, req.method, req.arg.as_ref())?;
+        } else {
+            host_call(
+                &self.target.link_name,
+                &self.target.contract_id,
+                req.method,
+                req.arg.as_ref(),
+            )?;
+        };
         Ok(res)
     }
 }

--- a/rpc-rs/src/wasmbus_core.rs
+++ b/rpc-rs/src/wasmbus_core.rs
@@ -5,7 +5,7 @@
 #[allow(unused_imports)]
 use crate::{
     deserialize, serialize, Context, Message, MessageDispatch, RpcError, RpcResult, SendOpts,
-    Transport,
+    Timestamp, Transport,
 };
 #[allow(unused_imports)]
 use async_trait::async_trait;


### PR DESCRIPTION
@stevelr please take a look at this PR as I think this will fix the problem I'm having where actor to actor calls are being bubbled up to the host with an empty namespace field, which is the field required to identify an actor as a target.