### PR TITLE
Fixing bug

### DIFF
--- a/rpc-rs/Cargo.toml
+++ b/rpc-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmbus-rpc"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2018"
 authors = [ "wasmcloud Team" ]
 license = "Apache-2.0"

--- a/rpc-rs/src/actor_wasm.rs
+++ b/rpc-rs/src/actor_wasm.rs
@@ -99,14 +99,14 @@ impl Transport for WasmHost {
     ) -> std::result::Result<Vec<u8>, RpcError> {
         let res = if !self.target.public_key.is_empty() {
             // actor-to-actor calls use namespace for the actor target identifier
-            host_call("", &self.target.public_key, req.method, req.arg.as_ref())?;
+            host_call("", &self.target.public_key, req.method, req.arg.as_ref())?
         } else {
             host_call(
                 &self.target.link_name,
                 &self.target.contract_id,
                 req.method,
                 req.arg.as_ref(),
-            )?;
+            )?
         };
         Ok(res)
     }


### PR DESCRIPTION
Build process didn't catch a bug in the previous PR because it doesn't target wasm32-unknown-unknown when running rust check.