### PR TITLE
add set-timeout to Transport trait 

### DIFF
--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weld-codegen"
-version = "0.1.18"
+version = "0.2.0"
 edition = "2018"
 authors = [ "wasmcloud Team" ]
 license = "Apache-2.0"

--- a/codegen/src/codegen_rust.rs
+++ b/codegen/src/codegen_rust.rs
@@ -83,6 +83,7 @@ impl<'model> RustCodeGen<'model> {
     }
 }
 
+#[non_exhaustive]
 enum MethodArgFlags {
     Normal,
     // arg is type ToString
@@ -161,7 +162,7 @@ impl<'model> CodeGen for RustCodeGen<'model> {
         _params: &ParamMap,
     ) -> Result<()> {
         w.write(
-            r#"// This file is generated automatically using wasmcloud-weld and smithy model definitions
+            r#"// This file is generated automatically using weld-codegen and smithy model definitions
                //
             "#);
         match &self.namespace {
@@ -873,6 +874,10 @@ impl<'model> RustCodeGen<'model> {
                   /// Constructs a {}Sender with the specified transport
                   pub fn via(transport: T) -> Self {{
                       Self{{ transport }}
+                  }}
+                  
+                  pub fn set_timeout(&self, interval: std::time::Duration) {{
+                    self.transport.set_timeout(interval);
                   }}
               }}
             "#,

--- a/codegen/src/config.rs
+++ b/codegen/src/config.rs
@@ -7,6 +7,7 @@ use std::str::FromStr;
 use toml::Value as TomlValue;
 
 /// Output languages for code generation
+#[non_exhaustive]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum OutputLanguage {

--- a/codegen/src/error.rs
+++ b/codegen/src/error.rs
@@ -4,6 +4,7 @@ use thiserror::Error as ThisError;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
+#[non_exhaustive]
 #[derive(Debug, ThisError)]
 pub enum Error {
     #[error("missing input file: {0}")]

--- a/codegen/src/model.rs
+++ b/codegen/src/model.rs
@@ -234,7 +234,6 @@ pub fn has_default(model: &'_ Model, member: &MemberShape) -> bool {
 
     if id.namespace().eq(prelude_namespace_id()) {
         let name = id.shape_name().to_string();
-        eprintln!("has_default name={}", &name);
         cfg_if::cfg_if! {
             if #[cfg(feature = "BigInteger")] {
                 has = has || &name == "bigInteger";


### PR DESCRIPTION
This is a breaking change - adds setTimeout to Transport trait, bumping crate to 0.2.

Requires wasmbus-rpc 0.5 to use, but this crate needs to be published to crates.io first before wasmbus-rpc 0.5 can be published.

Signed-off-by: stevelr <steve@cosmonic.com>