### PR TITLE
fix(codegen): Uses rustls over native-tls

### DIFF
--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weld-codegen"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 authors = [ "wasmcloud Team" ]
 license = "Apache-2.0"
@@ -29,13 +29,13 @@ atelier_smithy = "0.2"
 bytes = "1.0"
 cfg-if = "1.0"
 directories = "4.0"
-downloader = "0.2"
+downloader = { version = "0.2", features = ["rustls-tls"], default-features = false }
 handlebars = "4.0"
 Inflector = "0.11"
 lazy_static = "1.4"
 lexical-sort = "0.3"
 minicbor = { version = "0.11", features = ["derive", "std", "half" ] }
-reqwest = { version = "0.11", features = [ "blocking" ] }
+reqwest = { version = "0.11", default-features = false, features = [ "blocking", "rustls-tls" ] }
 rustc-hash = { version = "1.1", default_features = false }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
We discovered that in certain situations (particularly with cross compiling) when
including an interface using a path, the build would fail. This was due to
codegen using native-tls. Still not sure exactly _why_ this happened only during
build.rs stuff, but it did. Seeing as including a directory from a path could be
common in private monorepos, we switched out our dependencies so they no longer
used native-tls.

Once merged, this will need to be released as a patch fix