### PR TITLE
wasmbus-rpc 0.7.0-alpha.1

### DIFF
--- a/rpc-rs/CHANGELOG.md
+++ b/rpc-rs/CHANGELOG.md
@@ -1,0 +1,18 @@
+# wasmbus-rpc Changelog
+
+## 0.7.0-alpha.1
+
+### Features
+
+- replaced `ratsio` with `nats-aflowt`
+  - `nats-aflowt` is reexported as `wasmbus_rpc::anats`
+- removed dependency on nats-io/nats.rs (official nats client crate)
+- `RpcClient::request` obeys the `timeout` parameter in `RpcClient::new(..)`
+ 
+### Breaking changes (since 0.6.x)
+
+- removed support for rpc_client types `Sync` and `Asynk`. Only `Async` now.
+- `provider::NatsClient` changed type and is `anats::Connection`
+- type `Subscription` is no longer exported (now: anats::Subscription)
+- `HostBridge::new` - nats parameter no longer enclosed in Arc<>
+- `get_async` returns `Option<anats::Connection>` instead of `Option<Arc<NatsClient>>`

--- a/rpc-rs/Cargo.toml
+++ b/rpc-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmbus-rpc"
-version = "0.6.1"
+version = "0.7.0-alpha.1"
 authors = [ "wasmcloud Team" ]
 license = "Apache-2.0"
 description = "Runtime library for actors and capability providers"
@@ -45,12 +45,9 @@ num-bigint = { version = "0.4", optional = true }
 bigdecimal = { version = "0.3", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-nats = "0.16"
 tokio = { version = "1", features = ["full"]}
 futures = "0.3"
-# work-around "conflicting implementations of From<std::io::Error>" in ratsio build
-#ratsio = "0.4.0-alpha.1"
-ratsio = { version = "0.4.1", package="ratsio_fork_040" }
+nats-aflowt = "0.16.101"
 once_cell = "1.8"
 crossbeam = "0.8"
 uuid = { version = "0.8", features=["v4", "serde"] }

--- a/rpc-rs/Cargo.toml
+++ b/rpc-rs/Cargo.toml
@@ -47,7 +47,7 @@ bigdecimal = { version = "0.3", optional = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1", features = ["full"]}
 futures = "0.3"
-nats-aflowt = "0.16.102"
+nats-aflowt = "0.16.103"
 once_cell = "1.8"
 crossbeam = "0.8"
 uuid = { version = "0.8", features=["v4", "serde"] }

--- a/rpc-rs/Cargo.toml
+++ b/rpc-rs/Cargo.toml
@@ -47,7 +47,7 @@ bigdecimal = { version = "0.3", optional = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1", features = ["full"]}
 futures = "0.3"
-nats-aflowt = "0.16.101"
+nats-aflowt = "0.16.102"
 once_cell = "1.8"
 crossbeam = "0.8"
 uuid = { version = "0.8", features=["v4", "serde"] }

--- a/rpc-rs/Makefile
+++ b/rpc-rs/Makefile
@@ -19,15 +19,8 @@ lint:
 validate:
 	$(WELD) validate
 
-ifeq ($(shell docker ps | grep --regexp "nats:2.*/nats-server.* Up "),)
-test::
-	docker run --rm -d --name rpc_test_nats -p 127.0.0.1:4222:4222 nats:2.6 -js
-	cargo test -- --nocapture
-	docker stop rpc_test_nats
-else
 test::
 	cargo test -- --nocapture
-endif
 
 test::
 	cargo clippy --all-features --all-targets

--- a/rpc-rs/src/common.rs
+++ b/rpc-rs/src/common.rs
@@ -37,11 +37,13 @@ pub struct SendOpts {
 }
 
 impl SendOpts {
+    #[must_use]
     pub fn idempotent(mut self, val: bool) -> SendOpts {
         self.idempotent = val;
         self
     }
 
+    #[must_use]
     pub fn read_only(mut self, val: bool) -> SendOpts {
         self.read_only = val;
         self

--- a/rpc-rs/src/provider.rs
+++ b/rpc-rs/src/provider.rs
@@ -3,6 +3,7 @@
 //! common provider wasmbus support
 //!
 
+pub use crate::rpc_client::make_uuid;
 use crate::{
     core::{
         HealthCheckRequest, HealthCheckResponse, HostData, Invocation, InvocationResponse,
@@ -11,13 +12,8 @@ use crate::{
     Message, MessageDispatch, RpcClient, RpcError,
 };
 use async_trait::async_trait;
-use futures::{future::JoinAll, StreamExt};
+use futures::future::JoinAll;
 use log::{debug, error, info, trace, warn};
-use pin_utils::pin_mut;
-// re-export ratsio crate for simpler version compatibility
-pub use ratsio::{self, NatsClient};
-// re-export make_uuid
-pub use crate::rpc_client::make_uuid;
 use serde::de::DeserializeOwned;
 use std::{
     borrow::Cow,
@@ -32,11 +28,7 @@ use tokio::sync::{oneshot, RwLock};
 // name of nats queue group for rpc subscription
 const RPC_SUBSCRIPTION_QUEUE_GROUP: &str = "rpc";
 
-type SubscriptionId = ratsio::NatsSid;
-
 pub type HostShutdownEvent = String;
-
-pub trait Subscription: futures::stream::Stream<Item = ratsio::NatsMessage> + Send + Sync {}
 
 pub trait ProviderDispatch: MessageDispatch + ProviderHandler {}
 trait ProviderImpl: ProviderDispatch + Send + Sync + Clone + 'static {}
@@ -44,7 +36,7 @@ trait ProviderImpl: ProviderDispatch + Send + Sync + Clone + 'static {}
 pub mod prelude {
     pub use crate::{
         core::LinkDefinition,
-        provider::{HostBridge, NatsClient, ProviderDispatch, ProviderHandler},
+        provider::{HostBridge, ProviderDispatch, ProviderHandler},
         provider_main::{
             get_host_bridge, load_host_data, provider_main, provider_run, provider_start,
         },
@@ -113,7 +105,10 @@ pub struct HostBridge {
 }
 
 impl HostBridge {
-    pub fn new(nats: Arc<NatsClient>, host_data: &HostData) -> Result<HostBridge, RpcError> {
+    pub fn new(
+        nats: crate::anats::Connection,
+        host_data: &HostData,
+    ) -> Result<HostBridge, RpcError> {
         let key = if host_data.is_test() {
             wascap::prelude::KeyPair::new_user()
         } else {
@@ -165,7 +160,7 @@ impl Deref for HostBridge {
 
 #[doc(hidden)]
 pub struct HostBridgeInner {
-    subs: RwLock<Vec<SubscriptionId>>,
+    subs: RwLock<Vec<crate::anats::Subscription>>,
     /// Table of actors that are bound to this provider
     /// Key is actor_id / actor public key
     links: RwLock<HashMap<String, LinkDefinition>>,
@@ -186,31 +181,33 @@ impl HostBridge {
             let mut sub_lock = self.subs.write().await;
             copy.append(&mut sub_lock);
         };
-        // async nats client
-        let nc = self.rpc_client().get_async().unwrap();
-        // unsubscribe each with server and de-register streams
-        for sid in copy.iter() {
-            // ignore return code; we're shutting down
-            if let Err(e) = nc.un_subscribe(sid).await {
+        // `drop`ping the Subscription doesn't close it - we need to unsubscribe
+        for sub in copy.into_iter() {
+            if let Err(e) = sub.close().await {
                 debug!("during shutdown, failure to unsubscribe: {}", e.to_string());
             }
         }
+        debug!("unsubscribed from all subscriptions");
     }
 
     // add subscription so we can unsubscribe_all later
-    async fn add_subscription(&self, sid: SubscriptionId) {
+    async fn add_subscription(&self, sub: crate::anats::Subscription) {
         let mut sub_lock = self.subs.write().await;
-        sub_lock.push(sid);
+        sub_lock.push(sub);
     }
 
     // parse incoming subscription message
     // if it fails deserialization, we can't really respond;
     // so log the error
-    fn parse_msg<T: DeserializeOwned>(&self, msg: &ratsio::NatsMessage, topic: &str) -> Option<T> {
+    fn parse_msg<T: DeserializeOwned>(
+        &self,
+        msg: &crate::anats::Message,
+        topic: &str,
+    ) -> Option<T> {
         match if self.host_data.is_test() {
-            serde_json::from_slice(&msg.payload).map_err(|e| RpcError::Deser(e.to_string()))
+            serde_json::from_slice(&msg.data).map_err(|e| RpcError::Deser(e.to_string()))
         } else {
-            crate::deserialize(&msg.payload)
+            crate::deserialize(&msg.data)
         } {
             Ok(item) => Some(item),
             Err(e) => {
@@ -273,104 +270,110 @@ impl HostBridge {
         );
 
         debug!("subscribing for rpc : {}", &rpc_topic);
-        let (sid, sub) = self
+        let sub = self
             .rpc_client()
             .get_async()
             .unwrap() // we are only async
-            .subscribe_with_group(rpc_topic.as_str(), RPC_SUBSCRIPTION_QUEUE_GROUP)
+            .queue_subscribe(&rpc_topic, RPC_SUBSCRIPTION_QUEUE_GROUP)
             .await
             .map_err(|e| RpcError::Nats(e.to_string()))?;
-        self.add_subscription(sid).await;
-        pin_mut!(sub);
-        let provider = provider.clone();
-
-        while let Some(msg) = sub.next().await {
-            match crate::deserialize::<Invocation>(&msg.payload) {
-                Ok(inv) => match self.validate_invocation(&inv).await {
-                    Ok(()) => {
-                        let provider = provider.clone();
-                        let rpc_client = self.rpc_client().clone();
-                        tokio::task::spawn(async move {
-                            trace!(
-                                "RPC Invocation: op:{} from:{}",
-                                &inv.operation,
-                                &inv.origin.public_key
+        self.add_subscription(sub.clone()).await;
+        let this = self.clone();
+        tokio::spawn(async move {
+            while let Some(msg) = sub.next().await {
+                match crate::deserialize::<Invocation>(&msg.data) {
+                    Ok(inv) => match this.validate_invocation(&inv).await {
+                        Ok(()) => {
+                            let provider = provider.clone();
+                            let rpc_client = this.rpc_client().clone();
+                            tokio::task::spawn(async move {
+                                trace!(
+                                    "RPC Invocation: op:{} from:{}",
+                                    &inv.operation,
+                                    &inv.origin.public_key
+                                );
+                                let response = match provider
+                                    .dispatch(
+                                        &crate::Context {
+                                            actor: Some(inv.origin.public_key.clone()),
+                                            ..Default::default()
+                                        },
+                                        Message {
+                                            method: &inv.operation,
+                                            arg: Cow::from(inv.msg),
+                                        },
+                                    )
+                                    .await
+                                {
+                                    Ok(msg) => InvocationResponse {
+                                        invocation_id: inv.id,
+                                        error: None,
+                                        msg: msg.arg.to_vec(),
+                                    },
+                                    Err(e) => {
+                                        error!(
+                                            "RPC Invocation failed: op:{} from:{}: {}",
+                                            &inv.operation, &inv.origin.public_key, e
+                                        );
+                                        InvocationResponse {
+                                            invocation_id: inv.id,
+                                            error: Some(e.to_string()),
+                                            msg: Vec::new(),
+                                        }
+                                    }
+                                };
+                                if let Some(reply_to) = msg.reply {
+                                    // Errors are published from inside the function, safe to ignore Result
+                                    let _ = publish_invocation_response(
+                                        &rpc_client,
+                                        reply_to,
+                                        response,
+                                    )
+                                    .await;
+                                }
+                            });
+                        }
+                        Err(s) => {
+                            error!(
+                                "Invocation validation failure: op:{} from:{} id:{} host:{}: {}",
+                                &inv.operation, &inv.origin.public_key, &inv.id, &inv.host_id, &s
                             );
-                            let response = match provider
-                                .dispatch(
-                                    &crate::Context {
-                                        actor: Some(inv.origin.public_key.clone()),
-                                        ..Default::default()
-                                    },
-                                    Message {
-                                        method: &inv.operation,
-                                        arg: Cow::from(inv.msg),
-                                    },
-                                )
-                                .await
-                            {
-                                Ok(msg) => InvocationResponse {
-                                    invocation_id: inv.id,
-                                    error: None,
-                                    msg: msg.arg.to_vec(),
-                                },
-                                Err(e) => {
-                                    error!(
-                                        "RPC Invocation failed: op:{} from:{}: {}",
-                                        &inv.operation, &inv.origin.public_key, e
-                                    );
+                            if let Some(reply_to) = msg.reply {
+                                // Errors are published from inside the function, safe to ignore Result
+                                let _ = publish_invocation_response(
+                                    this.rpc_client(),
+                                    reply_to,
                                     InvocationResponse {
                                         invocation_id: inv.id,
-                                        error: Some(e.to_string()),
+                                        error: Some(s),
                                         msg: Vec::new(),
-                                    }
-                                }
-                            };
-                            if let Some(reply_to) = msg.reply_to {
-                                // Errors are published from inside the function, safe to ignore Result
-                                let _ =
-                                    publish_invocation_response(&rpc_client, reply_to, response)
-                                        .await;
+                                    },
+                                )
+                                .await;
                             }
-                        });
-                    }
-                    Err(s) => {
-                        error!(
-                            "Invocation validation failure: op:{} from:{} id:{} host:{}: {}",
-                            &inv.operation, &inv.origin.public_key, &inv.id, &inv.host_id, &s
-                        );
-                        if let Some(reply_to) = msg.reply_to {
-                            // Errors are published from inside the function, safe to ignore Result
-                            let _ = publish_invocation_response(
-                                self.rpc_client(),
+                        }
+                    },
+                    Err(e) => {
+                        error!("Invocation deserialization failure: {}", e.to_string());
+                        if let Some(reply_to) = msg.reply {
+                            if let Err(e) = publish_invocation_response(
+                                this.rpc_client(),
                                 reply_to,
                                 InvocationResponse {
-                                    invocation_id: inv.id,
-                                    error: Some(s),
+                                    invocation_id: "invalid".to_string(),
+                                    error: Some(format!("Corrupt invocation: {}", e)),
                                     msg: Vec::new(),
                                 },
                             )
-                            .await;
+                            .await
+                            {
+                                error!("replying to rpc: {}", e);
+                            }
                         }
-                    }
-                },
-                Err(e) => {
-                    error!("Invocation deserialization failure: {}", e.to_string());
-                    if let Some(reply_to) = msg.reply_to {
-                        publish_invocation_response(
-                            &self.rpc_client(),
-                            reply_to,
-                            InvocationResponse {
-                                invocation_id: "invalid".to_string(),
-                                error: Some(format!("Corrupt invocation: {}", e)),
-                                msg: Vec::new(),
-                            },
-                        )
-                        .await?
                     }
                 }
             }
-        }
+        });
         Ok(())
     }
 
@@ -447,25 +450,22 @@ impl HostBridge {
             &self.lattice_prefix, &self.host_data.provider_key, self.host_data.link_name
         );
         debug!("subscribing for shutdown : {}", &shutdown_topic);
-        let (subscription_sid, mut sub) = self
+        let sub = self
             .rpc_client()
             .get_async()
             .unwrap() // we are only async
             .subscribe(&shutdown_topic)
             .await
             .map_err(|e| RpcError::Nats(e.to_string()))?;
+        // TODO: there should be validation on this message, but it's not signed by host yet
+        let msg = sub.next().await;
+
+        // Shutdown messages are unsigned (see https://github.com/wasmCloud/wasmcloud-otp/issues/256)
+        // so we can't verify that this came from a trusted source.
+        // When the above issue is fixed, verify the source and keep looping if it's invalid.
+        debug!("Received termination signal. Shutting down capability provider.");
         let (this, provider) = (self.clone(), provider.clone());
-
-        // this while loop doesn't actually loop - it accepts the first signal received.
-        // leaving it as a loop for now because it needs to check
-        // validate the host signature, and loop if validation fails.
-        #[allow(clippy::never_loop)]
-        while let Some(msg) = sub.next().await {
-            // Shutdown messages are unsigned (see https://github.com/wasmCloud/wasmcloud-otp/issues/256)
-            // so we can't verify that this came from a trusted source.
-            // When the above issue is fixed, verify the source and keep looping if it's invalid.
-            debug!("Received termination signal. Shutting down capability provider.");
-
+        if let Err(e) = tokio::spawn(async move {
             // Tell provider to shutdown - before we shut down nats subscriptions,
             // in case it needs to do any message passing during shutdown
             if let Err(e) = provider.shutdown().await {
@@ -473,28 +473,29 @@ impl HostBridge {
             }
 
             // drain all subscriptions except this one
-            self.unsubscribe_all().await;
-
-            // send ack to host
-            if let Some(reply_to) = msg.reply_to.as_ref() {
-                let data = b"shutting down".to_vec();
-                if let Err(e) = self.rpc_client().publish(reply_to, &data).await {
-                    error!(
-                        "failed to send shutdown response to host: {}",
-                        e.to_string()
-                    );
-                }
+            this.unsubscribe_all().await;
+        })
+        .await
+        {
+            error!("joining thread shutdown/unsubscribe task: {}", e);
+        }
+        // send ack to host
+        if let Some(crate::anats::Message {
+            reply: Some(reply_to),
+            ..
+        }) = msg.as_ref()
+        {
+            let data = b"shutting down".to_vec();
+            if let Err(e) = self.rpc_client().publish(reply_to, &data).await {
+                error!(
+                    "failed to send shutdown response to host: {}",
+                    e.to_string()
+                );
             }
-            break;
         }
 
-        // unsubscribe for shutdowns
-        let _ignore = this
-            .rpc_client()
-            .get_async()
-            .unwrap() // we are only async
-            .un_subscribe(&subscription_sid)
-            .await;
+        // unsubscribe from shutdown messages
+        let _ = sub.close().await; // ignore errors
 
         // signal main thread to quit
         if let Err(e) = shutdown_tx.send("bye".to_string()) {
@@ -513,39 +514,43 @@ impl HostBridge {
         );
 
         debug!("subscribing for link put : {}", &ldput_topic);
-        let (sid, mut sub) = self
+        let sub = self
             .rpc_client()
             .get_async()
             .unwrap() // we are only async
             .subscribe(&ldput_topic)
             .await
             .map_err(|e| RpcError::Nats(e.to_string()))?;
-        self.add_subscription(sid).await;
+        self.add_subscription(sub.clone()).await;
+        //let provider = provider.clone();
         let (this, provider) = (self.clone(), provider.clone());
-        while let Some(msg) = sub.next().await {
-            if let Some(ld) = this.parse_msg::<LinkDefinition>(&msg, "link.put") {
-                if this.is_linked(&ld.actor_id).await {
-                    warn!(
-                        "Ignoring duplicate link put for '{}' to '{}'.",
-                        &ld.actor_id, &ld.provider_id
-                    );
-                } else {
-                    info!("Linking '{}' with '{}'", &ld.actor_id, &ld.provider_id);
-                    match provider.put_link(&ld).await {
-                        Ok(true) => {
-                            this.put_link(ld).await;
-                        }
-                        Ok(false) => {
-                            // authorization failed or parameters were invalid
-                            warn!("put_link denied: {}", &ld.actor_id);
-                        }
-                        Err(e) => {
-                            error!("put_link {} failed: {}", &ld.actor_id, e.to_string());
+        tokio::spawn(async move {
+            // TODO(ss): do we need to pin it with stream() before iterating?
+            while let Some(msg) = sub.next().await {
+                if let Some(ld) = this.parse_msg::<LinkDefinition>(&msg, "link.put") {
+                    if this.is_linked(&ld.actor_id).await {
+                        warn!(
+                            "Ignoring duplicate link put for '{}' to '{}'.",
+                            &ld.actor_id, &ld.provider_id
+                        );
+                    } else {
+                        info!("Linking '{}' with '{}'", &ld.actor_id, &ld.provider_id);
+                        match provider.put_link(&ld).await {
+                            Ok(true) => {
+                                this.put_link(ld).await;
+                            }
+                            Ok(false) => {
+                                // authorization failed or parameters were invalid
+                                warn!("put_link denied: {}", &ld.actor_id);
+                            }
+                            Err(e) => {
+                                error!("put_link {} failed: {}", &ld.actor_id, e.to_string());
+                            }
                         }
                     }
                 }
             }
-        }
+        });
         Ok(())
     }
 
@@ -559,23 +564,24 @@ impl HostBridge {
             &self.lattice_prefix, &self.host_data.provider_key, &self.host_data.link_name
         );
         debug!("subscribing for link del : {}", &link_del_topic);
-        let (sid, mut sub) = self
+        let sub = self
             .rpc_client()
             .get_async()
             .unwrap() // we are only async
             .subscribe(&link_del_topic)
             .await
             .map_err(|e| RpcError::Nats(e.to_string()))?;
-        self.add_subscription(sid).await;
-        //let (this, provider) = (self.clone(), provider_impl.clone());
-        while let Some(msg) = sub.next().await {
-            let (this, provider) = (self.clone(), provider.clone());
-            if let Some(ld) = &this.parse_msg::<LinkDefinition>(&msg, "link.del") {
-                this.delete_link(&ld.actor_id).await;
-                // notify provider that link is deleted
-                provider.delete_link(&ld.actor_id).await;
+        self.add_subscription(sub.clone()).await;
+        let (this, provider) = (self.clone(), provider.clone());
+        tokio::spawn(async move {
+            while let Some(msg) = sub.next().await {
+                if let Some(ld) = &this.parse_msg::<LinkDefinition>(&msg, "link.del") {
+                    this.delete_link(&ld.actor_id).await;
+                    // notify provider that link is deleted
+                    provider.delete_link(&ld.actor_id).await;
+                }
             }
-        }
+        });
         Ok(())
     }
 
@@ -588,46 +594,49 @@ impl HostBridge {
             &self.lattice_prefix, &self.host_data.provider_key, &self.host_data.link_name
         );
 
-        let (sid, mut sub) = self
+        let sub = self
             .rpc_client()
             .get_async()
             .unwrap() // we are only async
             .subscribe(&topic)
             .await
             .map_err(|e| RpcError::Nats(e.to_string()))?;
-        self.add_subscription(sid).await;
-        while let Some(msg) = sub.next().await {
-            // placeholder arg
-            let arg = HealthCheckRequest {};
-            let resp = match provider.health_request(&arg).await {
-                Ok(resp) => resp,
-                Err(e) => {
-                    error!("error generating health check response: {}", &e.to_string());
-                    HealthCheckResponse {
-                        healthy: false,
-                        message: Some(e.to_string()),
-                    }
-                }
-            };
-            let buf = if self.host_data.is_test() {
-                Ok(serde_json::to_vec(&resp).unwrap())
-            } else {
-                crate::serialize(&resp)
-            };
-            match buf {
-                Ok(t) => {
-                    if let Some(reply_to) = msg.reply_to.as_ref() {
-                        if let Err(e) = self.rpc_client().publish(reply_to, &t).await {
-                            error!("failed sending health check response: {}", e.to_string());
+        self.add_subscription(sub.clone()).await;
+        let this = self.clone();
+        tokio::spawn(async move {
+            while let Some(msg) = sub.next().await {
+                // placeholder arg
+                let arg = HealthCheckRequest {};
+                let resp = match provider.health_request(&arg).await {
+                    Ok(resp) => resp,
+                    Err(e) => {
+                        error!("error generating health check response: {}", &e.to_string());
+                        HealthCheckResponse {
+                            healthy: false,
+                            message: Some(e.to_string()),
                         }
                     }
-                }
-                Err(e) => {
-                    // extremely unlikely that InvocationResponse would fail to serialize
-                    error!("failed serializing HealthCheckResponse: {}", e.to_string());
+                };
+                let buf = if this.host_data.is_test() {
+                    Ok(serde_json::to_vec(&resp).unwrap())
+                } else {
+                    crate::serialize(&resp)
+                };
+                match buf {
+                    Ok(t) => {
+                        if let Some(reply_to) = msg.reply.as_ref() {
+                            if let Err(e) = this.rpc_client().publish(reply_to, &t).await {
+                                error!("failed sending health check response: {}", e.to_string());
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        // extremely unlikely that InvocationResponse would fail to serialize
+                        error!("failed serializing HealthCheckResponse: {}", e.to_string());
+                    }
                 }
             }
-        }
+        });
         Ok(())
     }
 }

--- a/rpc-rs/src/provider_main.rs
+++ b/rpc-rs/src/provider_main.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     core::HostData,
-    provider::{HostBridge, NatsClient, ProviderDispatch},
+    provider::{HostBridge, ProviderDispatch},
     RpcError,
 };
 use once_cell::sync::OnceCell;
@@ -23,7 +23,7 @@ pub fn get_host_bridge() -> &'static HostBridge {
 }
 
 /// nats address to use if not included in initial HostData
-const DEFAULT_NATS_ADDR: &str = "0.0.0.0:4222";
+const DEFAULT_NATS_ADDR: &str = "nats://0.0.0.0:4222";
 
 /// Start provider services: tokio runtime, logger, nats, and rpc subscriptions
 pub fn provider_main<P>(provider_dispatch: P) -> Result<(), Box<dyn std::error::Error>>
@@ -69,6 +69,8 @@ pub async fn provider_run<P>(
 where
     P: ProviderDispatch + Send + Sync + Clone + 'static,
 {
+    use std::str::FromStr as _;
+
     // initialize logger
     let log_rx = crate::channel_log::init_logger()
         .map_err(|_| RpcError::ProviderInit("log already initialized".to_string()))?;
@@ -81,13 +83,18 @@ where
     );
 
     let nats_addr = if !host_data.lattice_rpc_url.is_empty() {
-        &host_data.lattice_rpc_url
+        host_data.lattice_rpc_url.as_str()
     } else {
         DEFAULT_NATS_ADDR
     };
+    let nats_server = nats_aflowt::ServerAddress::from_str(nats_addr).map_err(|e| {
+        RpcError::InvalidParameter(format!("Invalid nats server url '{}': {}", nats_addr, e))
+    })?;
 
     // Connect to nats
-    let nc = NatsClient::new(host_data.nats_options())
+    let nc = nats_aflowt::Options::default()
+        .max_reconnects(None)
+        .connect(vec![nats_server])
         .await
         .map_err(|e| {
             RpcError::ProviderInit(format!("nats connection to {} failed: {}", nats_addr, e))

--- a/rpc-rs/src/provider_main.rs
+++ b/rpc-rs/src/provider_main.rs
@@ -23,7 +23,7 @@ pub fn get_host_bridge() -> &'static HostBridge {
 }
 
 /// nats address to use if not included in initial HostData
-const DEFAULT_NATS_ADDR: &str = "nats://0.0.0.0:4222";
+const DEFAULT_NATS_ADDR: &str = "nats://127.0.0.1:4222";
 
 /// Start provider services: tokio runtime, logger, nats, and rpc subscriptions
 pub fn provider_main<P>(provider_dispatch: P) -> Result<(), Box<dyn std::error::Error>>

--- a/rpc-rs/tests/nats_sub.rs
+++ b/rpc-rs/tests/nats_sub.rs
@@ -1,25 +1,35 @@
 //! test nats subscriptions (queue and non-queue) with rpc_client
 #![cfg(test)]
 
-use futures::StreamExt;
-use ratsio::{NatsClient, NatsClientOptions};
-use tokio::time::Duration;
+use std::{str::FromStr as _, time::Duration};
 use wasmbus_rpc::{RpcClient, RpcError, RpcResult};
 
-const DEFAULT_NATS_ADDR: &str = "0.0.0.0:4222";
+//const DEFAULT_NATS_ADDR: &str = "nats://127.0.0.1:4222";
+const TEST_NATS_ADDR: &str = "demo.nats.io";
 const LATTICE_PREFIX: &str = "test_nats_sub";
 const HOST_ID: &str = "HOST_test_nats_sub";
 
 /// create async nats client for test (sender or receiver)
 async fn make_client() -> RpcResult<RpcClient> {
-    let nc = NatsClient::new(NatsClientOptions {
-        cluster_uris: DEFAULT_NATS_ADDR.into(),
-        ..Default::default()
-    })
-    .await
-    .map_err(|e| RpcError::ProviderInit(format!("nats connection failed: {}", e)))?;
+    let server_addr = wasmbus_rpc::anats::ServerAddress::from_str(TEST_NATS_ADDR).unwrap();
+    let nc = wasmbus_rpc::anats::Options::default()
+        .max_reconnects(None)
+        .connect(vec![server_addr])
+        .await
+        .map_err(|e| {
+            RpcError::ProviderInit(format!(
+                "nats connection to {} failed: {}",
+                TEST_NATS_ADDR, e
+            ))
+        })?;
     let kp = wascap::prelude::KeyPair::new_user();
-    let client = RpcClient::new(nc, LATTICE_PREFIX, kp, HOST_ID.to_string(), None);
+    let client = RpcClient::new(
+        nc,
+        LATTICE_PREFIX,
+        kp,
+        HOST_ID.to_string(),
+        Some(Duration::from_secs(5)),
+    );
     Ok(client)
 }
 
@@ -28,28 +38,26 @@ async fn listen(client: RpcClient, subject: &str, pattern: &str) -> tokio::task:
     let pattern = pattern.to_string();
     let nc = client.get_async().unwrap();
 
+    let pattern = regex::Regex::new(&pattern).unwrap();
+    let sub = nc.subscribe(&subject).await.expect("subscriber");
+
     tokio::task::spawn(async move {
         let mut count: u64 = 0;
-        let pattern = regex::Regex::new(&pattern).unwrap();
-        let (sid, mut sub) = nc.subscribe(&subject).await.expect("subscriber");
-        println!("{:?} listening subj: {}", &sid, &subject);
         while let Some(msg) = sub.next().await {
-            let payload = String::from_utf8_lossy(&msg.payload);
-            if !pattern.is_match(&payload) && &payload != "exit" {
+            let payload = String::from_utf8_lossy(&msg.data);
+            if !pattern.is_match(payload.as_ref()) && &payload != "exit" {
                 println!("ERROR: payload on {}: {}", &subject, &payload);
-                break;
             }
-            if let Some(reply_to) = msg.reply_to {
+            if let Some(reply_to) = msg.reply {
                 client.publish(&reply_to, b"ok").await.expect("reply");
-                //let _ = nc.publish(reply_to, b"ok").await.expect("reply");
             }
-            if &payload == "exit" {
-                let _ = nc.un_subscribe(&sid).await;
+            if payload == "exit" {
                 break;
             }
             count += 1;
         }
-        println!("{:?} exiting: {}", &sid, count);
+        println!("exiting: {}", count);
+        let _ = sub.close().await;
         count
     })
 }
@@ -58,14 +66,14 @@ async fn listen_bin(client: RpcClient, subject: &str) -> tokio::task::JoinHandle
     let subject = subject.to_string();
     let nc = client.get_async().unwrap();
 
+    let sub = nc.subscribe(&subject).await.expect("subscriber");
     tokio::task::spawn(async move {
         let mut count: u64 = 0;
-        let (sid, mut sub) = nc.subscribe(&subject).await.expect("subscriber");
-        println!("{:?} listening subj: {}", &sid, &subject);
+        println!("listening subj: {}", &subject);
         while let Some(msg) = sub.next().await {
-            let size = msg.payload.len();
+            let size = msg.data.len();
             let response = format!("{}", size);
-            if let Some(reply_to) = msg.reply_to {
+            if let Some(reply_to) = msg.reply {
                 client
                     .publish(&reply_to, response.as_bytes())
                     .await
@@ -73,11 +81,11 @@ async fn listen_bin(client: RpcClient, subject: &str) -> tokio::task::JoinHandle
             }
             count += 1;
             if size == 1 {
-                let _ = nc.un_subscribe(&sid).await;
                 break;
             }
         }
-        println!("{:?} exiting: {}", &sid, count);
+        let _ = sub.close().await;
+        println!("exiting: {}", count);
         count
     })
 }
@@ -96,27 +104,27 @@ async fn listen_queue(
     tokio::task::spawn(async move {
         let mut count: u64 = 0;
         let pattern = regex::Regex::new(&pattern).unwrap();
-        let (sid, mut sub) = nc
-            .subscribe_with_group(&subject, &queue)
+        let sub = nc
+            .queue_subscribe(&subject, &queue)
             .await
             .expect("group subscriber");
-        println!("{:?} listening subj: {} queue: {}", &sid, &subject, &queue);
+        println!("listening subj: {} queue: {}", &subject, &queue);
         while let Some(msg) = sub.next().await {
-            let payload = String::from_utf8_lossy(&msg.payload);
-            if !pattern.is_match(&payload) && &payload != "exit" {
+            let payload = String::from_utf8_lossy(&msg.data);
+            if !pattern.is_match(payload.as_ref()) && &payload != "exit" {
                 println!("ERROR: payload on {}: {}", &subject, &payload);
                 break;
             }
-            if let Some(reply_to) = msg.reply_to {
+            if let Some(reply_to) = msg.reply {
                 client.publish(&reply_to, b"ok").await.expect("reply");
             }
             if &payload == "exit" {
-                let _ = nc.un_subscribe(&sid).await;
+                let _ = sub.close().await;
                 break;
             }
             count += 1;
         }
-        println!("{:?} exiting: {}", &sid, count);
+        println!("exiting: {}", count);
         count
     })
 }
@@ -151,17 +159,14 @@ async fn test_message_size() -> Result<(), Box<dyn std::error::Error>> {
     let mut pass_count = 0;
     let sender = make_client().await.expect("creating bin sender");
     const TEST_SIZES: &[u32] = &[
-        100_000,
-        200_000,
-        300_000,
-        400_000,
-        500_000,
-        600_000,
-        700_000,
-        800_000,
-        900_000,
-        1_000_000,
-        (1024 * 1024),
+        100, 200,
+        // NOTE: if using 'demo.nats.io' as the test server,
+        // don't abuse it by running this test - only use larger sizes
+        // if testing against a local nats server.
+        //
+        // 100_000, 200_000, 300_000, 400_000, 500_000, 600_000, 700_000, 800_000, 900_000,
+        //1_000_000, (1024 * 1024),
+        // The last size must be 1: signal to listen_bin to exit
         1,
     ];
     for size in TEST_SIZES.iter() {
@@ -232,10 +237,12 @@ async fn queue_sub() -> Result<(), Box<dyn std::error::Error>> {
     let topic_one = format!("one_{}", &sub_name);
     let topic_two = format!("two_{}", &sub_name);
 
-    let thread1 = listen_queue(make_client().await?, &topic_one, "X", "^one").await;
-    let thread2 = listen_queue(make_client().await?, &topic_one, "X", "^one").await;
-    let thread3 = listen_queue(make_client().await?, &topic_two, "X", "^two").await;
-    sleep(1000).await;
+    let queue_name = uuid::Uuid::new_v4().to_string();
+
+    let thread1 = listen_queue(make_client().await?, &topic_one, &queue_name, "^one").await;
+    let thread2 = listen_queue(make_client().await?, &topic_one, &queue_name, "^one").await;
+    let thread3 = listen_queue(make_client().await?, &topic_two, &queue_name, "^two").await;
+    sleep(2000).await;
 
     let sender = make_client().await?;
     const SPLIT_TOTAL: usize = 6;


### PR DESCRIPTION
## wasmbus-rpc 0.7.0-alpha.1

- this is an "alpha" release so cargo won't automatically upgrade to this version unless it is specifically used as a dependency.

### Features

- replaced `ratsio` with `nats-aflowt`
  - `nats-aflowt` is reexported as `wasmbus_rpc::anats`
- removed dependency on nats-io/nats.rs (official nats client crate)
- `RpcClient::request` obeys the `timeout` parameter in `RpcClient::new(..)`

### Breaking changes (since 0.6.1)

- removed support for rpc_client types `Sync` and `Asynk`. Only `Async` now.
- `provider::NatsClient` changed type and is `anats::Connection`
- type `Subscription` is no longer exported (now: anats::Subscription)
- `HostBridge::new` - nats parameter no longer enclosed in Arc<>
- `get_async` returns `Option<anats::Connection>` instead of `Option<Arc<NatsClient>>`