### PR TITLE
Changed wasm imports/exports to compile for wasm32

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmbus-macros"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 authors = [ "wasmcloud Team" ]
 license = "Apache-2.0"

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -86,6 +86,7 @@ pub fn derive_actor(input: TokenStream) -> TokenStream {
     pub const HOST_API_VERSION : u32 = 1;
 
     #[link(wasm_import_module = "wasmbus")]
+    #[cfg(target_arch = "wasm32")]
     extern "C" {
         pub fn __guest_response(ptr: *const u8, len: usize);
         pub fn __guest_error(ptr: *const u8, len: usize);
@@ -98,6 +99,7 @@ pub fn derive_actor(input: TokenStream) -> TokenStream {
     }
 
     #[no_mangle]
+    #[cfg(target_arch = "wasm32")]
     pub extern "C" fn __guest_call(op_len: i32, req_len: i32) -> i32 {
         use std::slice;
 

--- a/rpc-rs/Cargo.toml
+++ b/rpc-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmbus-rpc"
-version = "0.7.2"
+version = "0.7.3"
 authors = [ "wasmcloud Team" ]
 license = "Apache-2.0"
 description = "Runtime library for actors and capability providers"
@@ -34,7 +34,7 @@ thiserror = "1.0"
 time = "0.3.7"
 tokio-timer = "0.2"
 toml = "0.5"
-wasmbus-macros = "0.1.6"
+wasmbus-macros = { path = "../macros", version = "0.1.7" }
 
 #BigInteger support
 num-bigint = { version = "0.4", optional = true }

--- a/rpc-rs/src/wasmbus_core.rs
+++ b/rpc-rs/src/wasmbus_core.rs
@@ -1,4 +1,4 @@
-// This file is generated automatically using wasmcloud/weld-codegen 0.3.0
+// This file is generated automatically using wasmcloud/weld-codegen 0.3.2
 
 #[allow(unused_imports)]
 use crate::{

--- a/rpc-rs/src/wasmbus_model.rs
+++ b/rpc-rs/src/wasmbus_model.rs
@@ -1,4 +1,4 @@
-// This file is generated automatically using wasmcloud/weld-codegen 0.3.0
+// This file is generated automatically using wasmcloud/weld-codegen 0.3.2
 #[allow(unused_imports)]
 use crate::error::{RpcError, RpcResult};
 #[allow(unused_imports)]


### PR DESCRIPTION
This enables users to run `cargo test --target=<native_target>` to run Rust unit tests for actors. No additional configuration is needed, though we could offer something like a config `alias` called `test-wasm` that specifies this flag. 

Running `cargo test` without the `target` specification will still fail as native platforms cannot execute wasm32-unknown-unknown.

I also bumped patch versions here because this shouldn't affect any public interface that we have as it only changes the `#[derive(Actor)]` macro. Please let me know if this is an incorrect assumption.