### PR TITLE
Feat/timestamp rustlog

### DIFF
--- a/rpc-rs/Cargo.toml
+++ b/rpc-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmbus-rpc"
-version = "0.7.3"
+version = "0.7.4"
 authors = [ "wasmcloud Team" ]
 license = "Apache-2.0"
 description = "Runtime library for actors and capability providers"

--- a/rpc-rs/Cargo.toml
+++ b/rpc-rs/Cargo.toml
@@ -58,4 +58,4 @@ regex = "1"
 env_logger = "0.9.0"
 
 [build-dependencies]
-weld-codegen = "0.3.0"
+weld-codegen = "0.3.3"

--- a/rpc-rs/src/channel_log.rs
+++ b/rpc-rs/src/channel_log.rs
@@ -11,7 +11,6 @@ use log::{Level, Metadata, Record};
 use once_cell::sync::OnceCell;
 use std::{
     fmt,
-    str::FromStr,
     sync::atomic::{AtomicUsize, Ordering},
 };
 
@@ -116,14 +115,6 @@ pub fn init_logger() -> Result<Receiver, String> {
     ) {
         Err(format!("logger init error: {}", e))
     } else {
-        let mut detail_level = log::LevelFilter::Info;
-        if let Ok(level) = std::env::var("RUST_LOG") {
-            if let Ok(level) = log::LevelFilter::from_str(&level) {
-                detail_level = level;
-            }
-        }
-        eprintln!("Initializing logging at level {}\r", &detail_level);
-        log::set_max_level(detail_level);
         Ok(rx)
     }
 }

--- a/rpc-rs/src/error.rs
+++ b/rpc-rs/src/error.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 /// An error that can occur in the processing of an RPC. This is not request-specific errors but
 /// rather cross-cutting errors that can always occur.
-#[derive(thiserror::Error, Debug, Serialize, Deserialize)]
+#[derive(thiserror::Error, Debug, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum RpcError {
     /// The request exceeded its deadline.

--- a/rpc-rs/src/timestamp.rs
+++ b/rpc-rs/src/timestamp.rs
@@ -122,7 +122,7 @@ impl TryInto<SystemTime> for Timestamp {
         use std::time::Duration;
 
         let sys_now = SystemTime::now();
-        let now = Self::from(sys_now.clone()).as_nanos();
+        let now = Self::from(sys_now).as_nanos();
         let then = self.as_nanos();
         if now >= then {
             let delta_past = now - then;
@@ -175,14 +175,14 @@ fn timestamp_system_time() {
     let st = SystemTime::now()
         .checked_sub(std::time::Duration::from_secs(86_400 * 365 * 5))
         .unwrap();
-    let t = Timestamp::from(st.clone());
+    let t = Timestamp::from(st);
     assert_eq!(t.try_into(), Ok(st));
 
     // future
     let st = SystemTime::now()
         .checked_add(std::time::Duration::from_secs(86_400 * 365))
         .unwrap();
-    let t = Timestamp::from(st.clone());
+    let t = Timestamp::from(st);
     let st_check: SystemTime = t.try_into().unwrap();
     assert_eq!(st_check, st);
 }

--- a/rpc-rs/src/wasmbus_core.rs
+++ b/rpc-rs/src/wasmbus_core.rs
@@ -1,4 +1,4 @@
-// This file is generated automatically using wasmcloud/weld-codegen 0.3.2
+// This file is generated automatically using wasmcloud/weld-codegen 0.3.3
 
 #[allow(unused_imports)]
 use crate::{

--- a/rpc-rs/src/wasmbus_model.rs
+++ b/rpc-rs/src/wasmbus_model.rs
@@ -1,4 +1,4 @@
-// This file is generated automatically using wasmcloud/weld-codegen 0.3.2
+// This file is generated automatically using wasmcloud/weld-codegen 0.3.3
 #[allow(unused_imports)]
 use crate::error::{RpcError, RpcResult};
 #[allow(unused_imports)]


### PR DESCRIPTION
Version 0.7.4

**Fix**

- `RUST_LOG` environment setting for capability providers
  - previously, if the environment variable RUST_LOG was set to a level (`debug`, etc.) `provider_main` would honor that, but if parsing of the level value failed,RUST_LOG would be changed to `info`. The parsing did not accept other valid syntax such as `RUST_LOG=debug,hyper:error,tokio:info` . With this change any existing `RUST_LOG` environment setting is passed unchanged into env_logger.
  - This change is most useful for providers under test.

**Addition**

- Timestamp
  - added `new(secs,nsec)` constructor
  - added `Into<SystemTime>`