### PR TITLE
the last change (0.7.4) removed the call to log::set_max_level which …

### DIFF
--- a/rpc-rs/Cargo.toml
+++ b/rpc-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmbus-rpc"
-version = "0.7.4"
+version = "0.7.5"
 authors = [ "wasmcloud Team" ]
 license = "Apache-2.0"
 description = "Runtime library for actors and capability providers"

--- a/rpc-rs/src/channel_log.rs
+++ b/rpc-rs/src/channel_log.rs
@@ -115,6 +115,19 @@ pub fn init_logger() -> Result<Receiver, String> {
     ) {
         Err(format!("logger init error: {}", e))
     } else {
+        use std::str::FromStr as _;
+        let mut detail_level = log::LevelFilter::Info;
+        if let Ok(level) = std::env::var("RUST_LOG") {
+            let level = if let Some((left, _)) = level.split_once(',') {
+                left
+            } else {
+                &level
+            };
+            if let Ok(level) = log::LevelFilter::from_str(level) {
+                detail_level = level;
+            }
+        }
+        log::set_max_level(detail_level);
         Ok(rx)
     }
 }


### PR DESCRIPTION
In 0.7.4, the call to log::set_max_level was removed, preventing logging from being initialized for capability providers. This change puts it back, and adds the comma handling of RUST_LOG that should have been done before.

Bump crate to 0.7.5.

Signed-off-by: stevelr <steve@cosmonic.com>