### PR TITLE
bump to 0.4.2 to re-push to crates.io

### DIFF
--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weld-codegen"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 authors = [ "wasmcloud Team" ]
 license = "Apache-2.0"


### PR DESCRIPTION
0.4.1 was yanked but no changes are required. Updating version to push again

Signed-off-by: stevelr <steve@cosmonic.com>