### PR TITLE
- add not(target_arch=wasm32) to all cfg(chunkify )

### DIFF
--- a/rpc-rs/Cargo.toml
+++ b/rpc-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmbus-rpc"
-version = "0.8.1"
+version = "0.8.2"
 authors = [ "wasmcloud Team" ]
 license = "Apache-2.0"
 description = "Runtime library for actors and capability providers"
@@ -27,7 +27,6 @@ base64 = "0.13"
 cfg-if = "1.0"
 log = "0.4"
 minicbor = { version = "0.13", features = ["std", "partial-skip-support" ] }
-nkeys = "0.2"
 rmp-serde = { version = "0.15.4" }
 serde_bytes = "0.11"
 serde_json = "1.0"
@@ -49,6 +48,7 @@ tokio = { version = "1", features = ["full"]}
 futures = "0.3"
 nats-aflowt = "0.16.104"
 nats = { version = "0.17", optional=true }
+nkeys = "0.2"
 once_cell = "1.8"
 crossbeam = "0.8"
 uuid = { version = "0.8", features=["v4", "serde"] }

--- a/rpc-rs/src/actor_wasm.rs
+++ b/rpc-rs/src/actor_wasm.rs
@@ -2,8 +2,8 @@
 #![cfg(target_arch = "wasm32")]
 
 use crate::{
+    common::Message,
     error::{RpcError, RpcResult},
-    Message,
 };
 use async_trait::async_trait;
 

--- a/rpc-rs/src/chunkify.rs
+++ b/rpc-rs/src/chunkify.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "chunkify")]
+#![cfg(all(feature = "chunkify", not(target_arch = "wasm32")))]
 
 // You strike me as a message that has never been chunkified
 // I'm sure I don't know what you mean, You forget yourself

--- a/rpc-rs/src/lib.rs
+++ b/rpc-rs/src/lib.rs
@@ -47,7 +47,7 @@ pub type CallResult = std::result::Result<Vec<u8>, Box<dyn std::error::Error + S
 pub type HandlerResult<T> = std::result::Result<T, Box<dyn std::error::Error + Sync + Send>>;
 pub type TomlMap = toml::value::Map<String, toml::value::Value>;
 
-#[cfg(feature = "chunkify")]
+#[cfg(all(feature = "chunkify", not(target_arch = "wasm32")))]
 pub(crate) mod chunkify;
 mod wasmbus_core;
 

--- a/rpc-rs/src/provider.rs
+++ b/rpc-rs/src/provider.rs
@@ -3,7 +3,7 @@
 //! common provider wasmbus support
 //!
 
-#[cfg(feature = "chunkify")]
+#[cfg(all(feature = "chunkify", not(target_arch = "wasm32")))]
 use crate::chunkify::chunkify_endpoint;
 pub use crate::rpc_client::make_uuid;
 use crate::{
@@ -114,7 +114,7 @@ impl HostBridge {
         Self::new_client(NatsClientType::Async(nats), host_data)
     }
 
-    #[cfg(feature = "chunkify")]
+    #[cfg(all(feature = "chunkify", not(target_arch = "wasm32")))]
     pub(crate) fn new_sync_client(&self) -> RpcResult<nats::Connection> {
         //let key = if self.host_data.is_test() {
         //    wascap::prelude::KeyPair::new_user()
@@ -442,7 +442,7 @@ impl HostBridge {
     }
 
     async fn dechunk_validate(&self, inv: &mut Invocation) -> RpcResult<()> {
-        #[cfg(feature = "chunkify")]
+        #[cfg(all(feature = "chunkify", not(target_arch = "wasm32")))]
         if inv.content_length.is_some() && inv.content_length.unwrap() > inv.msg.len() as u64 {
             let inv_id = inv.id.clone();
             let lattice = self.rpc_client.lattice_prefix().to_string();
@@ -729,7 +729,7 @@ async fn publish_invocation_response(
 
     let response = {
         cfg_if! {
-            if #[cfg(feature="chunkify")] {
+            if #[cfg(all(feature = "chunkify", not(target_arch = "wasm32")))] {
                 let inv_id = response.invocation_id.clone();
                 if crate::chunkify::needs_chunking(response.msg.len()) {
                     let msg = response.msg;

--- a/rpc-rs/src/provider_main.rs
+++ b/rpc-rs/src/provider_main.rs
@@ -159,7 +159,7 @@ where
     let _ = shutdown_rx.await;
 
     // close chunkifiers
-    #[cfg(feature = "chunkify")]
+    #[cfg(all(feature = "chunkify", not(target_arch = "wasm32")))]
     crate::chunkify::shutdown();
 
     // stop the logger thread

--- a/rpc-rs/src/rpc_client.rs
+++ b/rpc-rs/src/rpc_client.rs
@@ -1,6 +1,6 @@
 #![cfg(not(target_arch = "wasm32"))]
 
-#[cfg(feature = "chunkify")]
+#[cfg(all(feature = "chunkify", not(target_arch = "wasm32")))]
 use crate::chunkify::chunkify_endpoint;
 use crate::{
     common::Message,
@@ -258,7 +258,7 @@ impl RpcClient {
         let len = message.arg.len();
         let chunkify = {
             cfg_if::cfg_if! {
-                if #[cfg(feature = "chunkify")] {
+                if #[cfg(all(feature = "chunkify", not(target_arch = "wasm32")))] {
                     crate::chunkify::needs_chunking(len)
                 } else {
                     false
@@ -287,7 +287,7 @@ impl RpcClient {
         };
         let nats_body = crate::common::serialize(&invocation)?;
 
-        #[cfg(feature = "chunkify")]
+        #[cfg(all(feature = "chunkify", not(target_arch = "wasm32")))]
         if let Some(body) = body {
             let inv_id = invocation.id.clone();
             debug!("chunkifying inv {} size {}", &inv_id, len);
@@ -344,7 +344,7 @@ impl RpcClient {
             match inv_response.error {
                 None => {
                     // was response chunked?
-                    #[cfg(feature = "chunkify")]
+                    #[cfg(all(feature = "chunkify", not(target_arch = "wasm32")))]
                     let msg = if inv_response.content_length.is_some()
                         && inv_response.content_length.unwrap() > inv_response.msg.len() as u64
                     {
@@ -418,8 +418,6 @@ impl RpcClient {
             // These two never get invoked
             #[cfg(feature = "async_rewrite")]
             NatsClientType::AsyncRewrite(_) => unimplemented!(),
-            //#[cfg(feature = "chunkify")]
-            //NatsClientType::Sync(_) => unimplemented!(),
         }
         Ok(())
     }

--- a/rpc-rs/src/wasmbus_core.rs
+++ b/rpc-rs/src/wasmbus_core.rs
@@ -1,4 +1,4 @@
-// This file is generated automatically using wasmcloud/weld-codegen 0.4.0
+// This file is generated automatically using wasmcloud/weld-codegen 0.4.1
 
 #[allow(unused_imports)]
 use crate::{

--- a/rpc-rs/src/wasmbus_model.rs
+++ b/rpc-rs/src/wasmbus_model.rs
@@ -1,4 +1,4 @@
-// This file is generated automatically using wasmcloud/weld-codegen 0.4.0
+// This file is generated automatically using wasmcloud/weld-codegen 0.4.1
 #[allow(unused_imports)]
 use crate::error::{RpcError, RpcResult};
 #[allow(unused_imports)]


### PR DESCRIPTION
- move nkeys into not-wasm32 dependencies
- bump to 0.8.2

Signed-off-by: stevelr <steve@cosmonic.com>