### PR TITLE
fix(rpc): Prevents early provider exit when logger is set

### DIFF
--- a/rpc-rs/Cargo.toml
+++ b/rpc-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmbus-rpc"
-version = "0.8.2"
+version = "0.8.3"
 authors = [ "wasmcloud Team" ]
 license = "Apache-2.0"
 description = "Runtime library for actors and capability providers"


### PR DESCRIPTION
Previous to this change, if a provider set a logger, it would cause the provider
to exit early. This changes the setup to simply log a message if the provider
already created a logger rather than exiting early