### PR TITLE
Update async-nats dependency in wasmbus-rpc to 0.20.0

### DIFF
--- a/rpc-rs/Cargo.toml
+++ b/rpc-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmbus-rpc"
-version = "0.10.1"
+version = "0.10.2"
 authors = [ "wasmcloud Team" ]
 license = "Apache-2.0"
 description = "Runtime library for actors and capability providers"
@@ -50,7 +50,7 @@ bigdecimal = { version = "0.3", optional = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
-async-nats = "0.18.0"
+async-nats = "0.20.0"
 nats = "0.22.0"
 nkeys = "0.2"
 once_cell = "1.8"


### PR DESCRIPTION
This updates async-nats to 0.20.0 so that clients attempting to use the OTel related code can use it with newer releases of the async-nats client.