### PR TITLE
update to async-nats with jetstream objectstore and new headers api

### DIFF
--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weld-codegen"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 authors = [ "wasmcloud Team" ]
 license = "Apache-2.0"

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/wasmcloud/weld"
 repository = "https://github.com/wasmcloud/weld"
 documentation = "https://docs.rs/weld-codegen"
 readme = "README.md"
-rust-version = "1.57.0"
+rust-version = "1.60.0"
 
 [features]
 default = [ "wasmbus" ]

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weld-codegen"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = [ "wasmcloud Team" ]
 license = "Apache-2.0"
@@ -26,7 +26,7 @@ atelier_json = "0.2"
 atelier_smithy = "0.2"
 bytes = "1.0"
 cfg-if = "1.0"
-clap = { version = "3.1", features = [ "derive" ] }
+clap = { version = "4.0.22", features = [ "derive" ] }
 directories = "4.0"
 downloader = { version = "0.2", features = ["rustls-tls"], default-features = false }
 handlebars = "4.0"

--- a/codegen/bin/dump-smithy-model.rs
+++ b/codegen/bin/dump-smithy-model.rs
@@ -6,10 +6,10 @@ use std::path::PathBuf;
 use weld_codegen::{config::CodegenConfig, sources_to_model};
 
 #[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None)]
 struct Args {
     /// codegen.toml file (default: "./codegen.toml")
-    #[clap(short, long)]
+    #[arg(short, long)]
     config: Option<PathBuf>,
 }
 

--- a/codegen/bin/gen.rs
+++ b/codegen/bin/gen.rs
@@ -19,7 +19,7 @@ fn main() -> Result<()> {
 }
 
 fn load_config(path: &Path) -> Result<CodegenConfig> {
-    let cfile = std::fs::read_to_string(&path)
+    let cfile = std::fs::read_to_string(path)
         .with_context(|| format!("reading config file at {}", &path.display()))?;
     let folder = path.parent().unwrap().to_path_buf();
     let folder = std::fs::canonicalize(folder)?;

--- a/codegen/src/codegen_go.rs
+++ b/codegen/src/codegen_go.rs
@@ -83,6 +83,7 @@ impl fmt::Display for DecodeRef {
     }
 }
 
+#[derive(Default)]
 #[allow(dead_code)]
 pub struct GoCodeGen<'model> {
     /// if set, limits declaration output to this namespace only
@@ -351,7 +352,7 @@ impl<'model> CodeGen for GoCodeGen<'model> {
             )"#,
             &self.package,
             if ns != wasmcloud_model_namespace() && ns != wasmcloud_core_namespace() {
-                "\"github.com/wasmcloud/actor-tinygo\" //nolint"
+                "core \"github.com/wasmcloud/interfaces/core/tinygo\" //nolint"
             } else {
                 // avoid circular dependencies - core and model are part of the actor-tinygo package
                 ""
@@ -784,9 +785,9 @@ impl<'model> GoCodeGen<'model> {
         let (fields, _is_numbered) = get_sorted_fields(ident, strukt)?;
         for member in fields.iter() {
             self.apply_documentation_traits(w, member.id(), member.traits());
-            let (field_name, _ser_name) = self.get_field_name_and_ser_name(member)?;
+            let (field_name, ser_name) = self.get_field_name_and_ser_name(member)?;
             let target = member.target();
-            let field_tags = "";
+            let field_tags = format!(r#"`json:"{}"`"#, ser_name);
             writeln!(
                 w,
                 "  {} {} {}",

--- a/codegen/src/codegen_go.rs
+++ b/codegen/src/codegen_go.rs
@@ -30,7 +30,8 @@ use crate::{
     gen::CodeGen,
     model::{
         get_operation, get_sorted_fields, get_trait, is_opt_namespace, value_to_json,
-        wasmcloud_actor_namespace, wasmcloud_core_namespace, wasmcloud_model_namespace, CommentKind, PackageName, Ty,
+        wasmcloud_actor_namespace, wasmcloud_core_namespace, wasmcloud_model_namespace,
+        CommentKind, PackageName, Ty,
     },
     render::Renderer,
     writer::Writer,

--- a/codegen/src/codegen_go.rs
+++ b/codegen/src/codegen_go.rs
@@ -30,7 +30,7 @@ use crate::{
     gen::CodeGen,
     model::{
         get_operation, get_sorted_fields, get_trait, is_opt_namespace, value_to_json,
-        wasmcloud_core_namespace, wasmcloud_model_namespace, CommentKind, PackageName, Ty,
+        wasmcloud_actor_namespace, wasmcloud_core_namespace, wasmcloud_model_namespace, CommentKind, PackageName, Ty,
     },
     render::Renderer,
     writer::Writer,
@@ -346,13 +346,15 @@ impl<'model> CodeGen for GoCodeGen<'model> {
             w,
             r#"package {}
             import (
-                {}
                 msgpack "github.com/wasmcloud/tinygo-msgpack" //nolint
                 cbor "github.com/wasmcloud/tinygo-cbor" //nolint
+                {}
             )"#,
             &self.package,
-            if ns != wasmcloud_model_namespace() && ns != wasmcloud_core_namespace() {
+            if ns == wasmcloud_actor_namespace() {
                 "core \"github.com/wasmcloud/interfaces/core/tinygo\" //nolint"
+            } else if ns != wasmcloud_model_namespace() && ns != wasmcloud_core_namespace() {
+                "actor \"github.com/wasmcloud/actor-tinygo\" //nolint"
             } else {
                 // avoid circular dependencies - core and model are part of the actor-tinygo package
                 ""

--- a/codegen/src/codegen_py.rs
+++ b/codegen/src/codegen_py.rs
@@ -115,7 +115,7 @@ impl<'model> CodeGen for PythonCodeGen<'model> {
     }
 
     fn source_formatter(&self, _: Vec<String>) -> Result<Box<dyn SourceFormatter>> {
-        Ok(Box::new(PythonSourceFormatter::default()))
+        Ok(Box::<PythonSourceFormatter>::default())
     }
 
     /// Perform any initialization required prior to code generation for a file

--- a/codegen/src/codegen_rust.rs
+++ b/codegen/src/codegen_rust.rs
@@ -56,6 +56,7 @@ struct Declaration(u8, BytesMut);
 
 type ShapeList<'model> = Vec<(&'model ShapeID, &'model AppliedTraits, &'model ShapeKind)>;
 
+#[derive(Default)]
 pub struct RustCodeGen<'model> {
     /// if set, limits declaration output to this namespace only
     pub(crate) namespace: Option<NamespaceID>,

--- a/codegen/src/docgen.rs
+++ b/codegen/src/docgen.rs
@@ -5,6 +5,7 @@ use std::{
 
 use atelier_core::model::Model;
 
+use crate::format::NullFormatter;
 use crate::{
     config::{LanguageConfig, OutputFile, OutputLanguage},
     error::Result,
@@ -74,7 +75,7 @@ impl CodeGen for DocGen {
             .map(|id| id.to_string())
             .collect::<BTreeSet<String>>();
 
-        std::fs::create_dir_all(&output_dir).map_err(|e| {
+        std::fs::create_dir_all(output_dir).map_err(|e| {
             Error::Io(format!(
                 "creating directory {}: {}",
                 output_dir.display(),
@@ -126,6 +127,6 @@ impl CodeGen for DocGen {
         name.into()
     }
     fn source_formatter(&self, _: Vec<String>) -> Result<Box<dyn SourceFormatter>> {
-        Ok(Box::new(crate::format::NullFormatter::default()))
+        Ok(Box::<NullFormatter>::default())
     }
 }

--- a/codegen/src/gen.rs
+++ b/codegen/src/gen.rs
@@ -14,12 +14,12 @@ use atelier_core::model::{
     HasIdentity as _, Identifier, Model,
 };
 
+use crate::docgen::DocGen;
 use crate::{
     codegen_go::GoCodeGen,
     codegen_py::PythonCodeGen,
     codegen_rust::RustCodeGen,
     config::{CodegenConfig, LanguageConfig, OutputFile, OutputLanguage},
-    docgen::DocGen,
     error::{Error, Result},
     format::{NullFormatter, SourceFormatter},
     model::{get_trait, serialization_trait, CommentKind, NumberedMember},
@@ -226,11 +226,11 @@ fn gen_for_language<'model>(
         OutputLanguage::Python => Box::new(PythonCodeGen::new(model)),
         OutputLanguage::TinyGo => Box::new(GoCodeGen::new(model, true)),
         OutputLanguage::Go => Box::new(GoCodeGen::new(model, false)),
-        OutputLanguage::Html => Box::new(DocGen::default()),
-        OutputLanguage::Poly => Box::new(PolyGen::default()),
+        OutputLanguage::Html => Box::<DocGen>::default(),
+        OutputLanguage::Poly => Box::<PolyCodeGen>::default(),
         _ => {
             crate::error::print_warning(&format!("Target language {} not implemented", language));
-            Box::new(NoCodeGen::default())
+            Box::<NoCodeGen>::default()
         }
     }
 }
@@ -494,8 +494,8 @@ fn ensure_files_exist(source_files: &[std::path::PathBuf]) -> Result<()> {
 }
 
 #[derive(Debug, Default)]
-struct PolyGen {}
-impl CodeGen for PolyGen {
+struct PolyCodeGen {}
+impl CodeGen for PolyCodeGen {
     fn output_language(&self) -> OutputLanguage {
         OutputLanguage::Poly
     }
@@ -515,7 +515,7 @@ impl CodeGen for PolyGen {
     }
 
     fn source_formatter(&self, _: Vec<String>) -> Result<Box<dyn SourceFormatter>> {
-        Ok(Box::new(NullFormatter::default()))
+        Ok(Box::<NullFormatter>::default())
     }
 }
 
@@ -625,6 +625,6 @@ impl CodeGen for NoCodeGen {
     }
 
     fn source_formatter(&self, _: Vec<String>) -> Result<Box<dyn SourceFormatter>> {
-        Ok(Box::new(NullFormatter::default()))
+        Ok(Box::<NullFormatter>::default())
     }
 }

--- a/codegen/src/loader.rs
+++ b/codegen/src/loader.rs
@@ -230,16 +230,14 @@ fn urls_to_cached_files(urls: Vec<String>) -> Result<Vec<PathBuf>> {
                                 Error::Other(format!("internal download error {}", e))
                             })?;
                             let cache_file = weld_cache.join(rel_path);
-                            std::fs::create_dir_all(&cache_file.parent().unwrap()).map_err(
-                                |e| {
-                                    Error::Io(format!(
-                                        "creating folder {}: {}",
-                                        &cache_file.parent().unwrap().display(),
-                                        e
-                                    ))
-                                },
-                            )?;
-                            std::fs::copy(&downloaded_file, &cache_file).map_err(|e| {
+                            std::fs::create_dir_all(cache_file.parent().unwrap()).map_err(|e| {
+                                Error::Io(format!(
+                                    "creating folder {}: {}",
+                                    &cache_file.parent().unwrap().display(),
+                                    e
+                                ))
+                            })?;
+                            std::fs::copy(downloaded_file, &cache_file).map_err(|e| {
                                 Error::Other(format!(
                                     "writing cache file {}: {}",
                                     &cache_file.display(),

--- a/codegen/src/model.rs
+++ b/codegen/src/model.rs
@@ -23,6 +23,7 @@ use crate::{
 
 const WASMCLOUD_MODEL_NAMESPACE: &str = "org.wasmcloud.model";
 const WASMCLOUD_CORE_NAMESPACE: &str = "org.wasmcloud.core";
+const WASMCLOUD_ACTOR_NAMESPACE: &str = "org.wasmcloud.actor";
 
 const TRAIT_CODEGEN_RUST: &str = "codegenRust";
 // If any of these are needed, they would have to be defined in core namespace
@@ -41,6 +42,8 @@ lazy_static! {
         NamespaceID::new_unchecked(WASMCLOUD_MODEL_NAMESPACE);
     static ref WASMCLOUD_CORE_NAMESPACE_ID: NamespaceID =
         NamespaceID::new_unchecked(WASMCLOUD_CORE_NAMESPACE);
+    static ref WASMCLOUD_ACTOR_NAMESPACE_ID: NamespaceID =
+        NamespaceID::new_unchecked(WASMCLOUD_ACTOR_NAMESPACE);
     static ref SERIALIZATION_TRAIT_ID: ShapeID = ShapeID::new(
         NamespaceID::new_unchecked(WASMCLOUD_MODEL_NAMESPACE),
         Identifier::from_str(TRAIT_SERIALIZATION).unwrap(),
@@ -80,6 +83,9 @@ pub fn wasmcloud_model_namespace() -> &'static NamespaceID {
 }
 pub fn wasmcloud_core_namespace() -> &'static NamespaceID {
     &WASMCLOUD_CORE_NAMESPACE_ID
+}
+pub fn wasmcloud_actor_namespace() -> &'static NamespaceID {
+    &WASMCLOUD_ACTOR_NAMESPACE_ID
 }
 
 #[cfg(feature = "wasmbus")]

--- a/codegen/src/render.rs
+++ b/codegen/src/render.rs
@@ -249,7 +249,7 @@ impl HelperDef for NamespaceHelper {
     ) -> Result<ScopedJson<'reg, 'rc>, RenderError> {
         let namespace = arg_as_string(h, 0, "filter_namespace")?;
         let namespace = NamespaceID::from_str(namespace)
-            .map_err(|e| RenderError::new(&format!("invalid namespace {}", e)))?;
+            .map_err(|e| RenderError::new(format!("invalid namespace {}", e)))?;
         let obj = arg_as_obj(h, 1, "filter_namespace")?;
 
         let shapes = obj
@@ -466,7 +466,7 @@ fn add_base_helpers(hb: &mut Handlebars) {
                 // get first arg as string
                 let id = arg_as_string(h, 0, "namespace")?;
                 let id = ShapeID::from_str(id).map_err(|e| {
-                    RenderError::new(&format!("invalid shape id {} for namespace_name", e))
+                    RenderError::new(format!("invalid shape id {} for namespace_name", e))
                 })?;
                 out.write(&id.namespace().to_string())?;
                 Ok(())
@@ -530,7 +530,7 @@ fn add_base_helpers(hb: &mut Handlebars) {
              -> HelperResult {
                 let id = arg_as_string(h, 0, "shape_name")?;
                 let id = ShapeID::from_str(id).map_err(|e| {
-                    RenderError::new(&format!("invalid shape id {} for shape_name", e))
+                    RenderError::new(format!("invalid shape id {} for shape_name", e))
                 })?;
                 out.write(&id.shape_name().to_string())?;
                 Ok(())
@@ -552,7 +552,7 @@ fn add_base_helpers(hb: &mut Handlebars) {
              -> HelperResult {
                 let id = arg_as_string(h, 0, "member_name")?;
                 let id = Identifier::from_str(id).map_err(|e| {
-                    RenderError::new(&format!("invalid member id {} for member_name", e))
+                    RenderError::new(format!("invalid member id {} for member_name", e))
                 })?;
                 out.write(&id.to_string())?;
                 Ok(())

--- a/docgen/dev/package.json
+++ b/docgen/dev/package.json
@@ -4,7 +4,7 @@
   "description": "build tailwind css",
   "main": "postcss.config.js",
   "dependencies": {
-    "@tailwindcss/typography": "^0.4.0",
+    "@tailwindcss/typography": "^0.5.0",
     "alpinejs": "^2.8.0"
   },
   "devDependencies": {

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://github.com/wasmcloud/weld"
 repository = "https://github.com/wasmcloud/weld"
 documentation = "https://docs.rs/wasmcloud-weld-macros"
 readme = "README.md"
+rust-version = "1.56.1"
 
 [lib]
 proc-macro = true

--- a/rpc-rs/CHANGELOG.md
+++ b/rpc-rs/CHANGELOG.md
@@ -5,6 +5,7 @@
 - upgrade to async-nats 0.22.0 
 - additional logging on reconnect 
 - add json tags to generated tinygo struct declarations
+- bumped chunkify threshold to 900KiB \(900\*1024\) to match host threshold
  
 
 ## 0.10.0

--- a/rpc-rs/CHANGELOG.md
+++ b/rpc-rs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # wasmbus-rpc Changelog
 
+## 0.11.0
+
+- upgrade to async-nats 0.21.0 
+- additional logging on reconnect 
+ 
+
 ## 0.10.0
 
 - upgrade to async-nats 0.18.0

--- a/rpc-rs/CHANGELOG.md
+++ b/rpc-rs/CHANGELOG.md
@@ -1,9 +1,10 @@
 # wasmbus-rpc Changelog
 
-## 0.11.0
+## 0.11.0-alpha.1
 
-- upgrade to async-nats 0.21.0 
+- upgrade to async-nats 0.22.0 
 - additional logging on reconnect 
+- add json tags to generated tinygo struct declarations
  
 
 ## 0.10.0

--- a/rpc-rs/Cargo.toml
+++ b/rpc-rs/Cargo.toml
@@ -66,7 +66,7 @@ opentelemetry-otlp = { version = "0.11", features = ["http-proto", "reqwest-clie
 
 prometheus = { version = "0.13", optional = true }
 
-#[dev-dependencies]
+[dev-dependencies]
 regex = "1"
 clap = { version = "4.0.9", features = ["derive"] }
 

--- a/rpc-rs/Cargo.toml
+++ b/rpc-rs/Cargo.toml
@@ -46,7 +46,7 @@ num-bigint = { version = "0.4", optional = true }
 bigdecimal = { version = "0.3", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-async-nats = { git = "https://github.com/nats-io/nats.rs" }
+async-nats = "0.22.0"
 atty = "0.2"
 data-encoding = "2.3"
 futures = "0.3"

--- a/rpc-rs/Cargo.toml
+++ b/rpc-rs/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/wasmbus-rpc"
 readme = "README.md"
 edition = "2021"
 # MSRV
-rust-version = "1.58.1"
+rust-version = "1.64"
 
 # don't push build.rs
 exclude = [ "build.rs" ]

--- a/rpc-rs/Cargo.toml
+++ b/rpc-rs/Cargo.toml
@@ -23,7 +23,6 @@ metrics = [ "prometheus" ]
 otel = ["opentelemetry", "tracing-opentelemetry", "opentelemetry-otlp"]
 
 [dependencies]
-anyhow = "1.0.57"
 async-trait = "0.1"
 base64 = "0.13"
 bytes = "1.1.0"
@@ -34,8 +33,7 @@ serde_bytes = "0.11"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
-time = "0.3.13"
-tokio-timer = "0.2"
+time = "0.3.16"
 toml = "0.5"
 tracing = { version = "0.1.34", features = ["log"] }
 tracing-futures = "0.2"
@@ -66,9 +64,10 @@ uuid = { version = "1.0", features = ["v4", "serde"] }
 wascap = "0.8.0"
 
 [dev-dependencies]
+anyhow = "1.0.66"
 regex = "1"
-clap = { version = "4.0.10", features = ["derive"] }
+clap = { version = "4.0.22", features = ["derive"] }
 test-log = { version = "0.2.10", default-features = false, features = ["trace"] }
 
 [build-dependencies]
-weld-codegen = { version = "0.5.0", path = "../codegen" }
+weld-codegen = { version = "0.5.1", path = "../codegen" }

--- a/rpc-rs/Cargo.toml
+++ b/rpc-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmbus-rpc"
-version = "0.10.1"
+version = "0.11.0"
 authors = [ "wasmcloud Team" ]
 license = "Apache-2.0"
 description = "Runtime library for actors and capability providers"
@@ -50,8 +50,7 @@ bigdecimal = { version = "0.3", optional = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
-async-nats = "0.18.0"
-nats = "0.22.0"
+async-nats = { git = "https://github.com/nats-io/nats.rs", rev = "3ad65d3c44bb5459f0fe5424b4e41fb2f96ec3df" }
 nkeys = "0.2"
 once_cell = "1.8"
 uuid = { version = "1.0", features = ["v4", "serde"] }
@@ -60,16 +59,16 @@ sha2 = "0.10.2"
 data-encoding = "2.3"
 tracing-subscriber = { version = "0.3.7", features = ["env-filter", "json"] }
 atty = "0.2"
-opentelemetry = { version = "0.17", features = ["rt-tokio"], optional = true }
-tracing-opentelemetry = { version = "0.17", optional = true }
+opentelemetry = { version = "0.18", features = ["rt-tokio"], optional = true }
+tracing-opentelemetry = { version = "0.18", optional = true }
 lazy_static = "1.4"
-opentelemetry-otlp = { version = "0.10", features = ["http-proto", "reqwest-client"], optional = true }
+opentelemetry-otlp = { version = "0.11", features = ["http-proto", "reqwest-client"], optional = true }
 
 prometheus = { version = "0.13", optional = true }
 
-[dev-dependencies]
+#[dev-dependencies]
 regex = "1"
-clap = { version = "3.2.5", features = ["derive"] }
+clap = { version = "4.0.9", features = ["derive"] }
 
 [build-dependencies]
 weld-codegen = { version = "0.5.0", path = "../codegen" }

--- a/rpc-rs/Cargo.toml
+++ b/rpc-rs/Cargo.toml
@@ -50,7 +50,7 @@ bigdecimal = { version = "0.3", optional = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
-async-nats = { git = "https://github.com/nats-io/nats.rs", rev = "3ad65d3c44bb5459f0fe5424b4e41fb2f96ec3df" }
+async-nats = "0.21.0"
 nkeys = "0.2"
 once_cell = "1.8"
 uuid = { version = "1.0", features = ["v4", "serde"] }
@@ -68,7 +68,7 @@ prometheus = { version = "0.13", optional = true }
 
 [dev-dependencies]
 regex = "1"
-clap = { version = "4.0.9", features = ["derive"] }
+clap = { version = "4.0.10", features = ["derive"] }
 
 [build-dependencies]
 weld-codegen = { version = "0.5.0", path = "../codegen" }

--- a/rpc-rs/Cargo.toml
+++ b/rpc-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmbus-rpc"
-version = "0.11.0"
+version = "0.11.0-alpha.1"
 authors = [ "wasmcloud Team" ]
 license = "Apache-2.0"
 description = "Runtime library for actors and capability providers"
@@ -48,27 +48,27 @@ num-bigint = { version = "0.4", optional = true }
 bigdecimal = { version = "0.3", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1", features = ["full"] }
+async-nats = { git = "https://github.com/nats-io/nats.rs" }
+atty = "0.2"
+data-encoding = "2.3"
 futures = "0.3"
-async-nats = "0.21.0"
+lazy_static = "1.4"
 nkeys = "0.2"
 once_cell = "1.8"
+opentelemetry = { version = "0.18", features = ["rt-tokio"], optional = true }
+opentelemetry-otlp = { version = "0.11", features = ["http-proto", "reqwest-client"], optional = true }
+prometheus = { version = "0.13", optional = true }
+sha2 = "0.10.2"
+tokio = { version = "1", features = ["full"] }
+tracing-opentelemetry = { version = "0.18", optional = true }
+tracing-subscriber = { version = "0.3.7", features = ["env-filter", "json"] }
 uuid = { version = "1.0", features = ["v4", "serde"] }
 wascap = "0.8.0"
-sha2 = "0.10.2"
-data-encoding = "2.3"
-tracing-subscriber = { version = "0.3.7", features = ["env-filter", "json"] }
-atty = "0.2"
-opentelemetry = { version = "0.18", features = ["rt-tokio"], optional = true }
-tracing-opentelemetry = { version = "0.18", optional = true }
-lazy_static = "1.4"
-opentelemetry-otlp = { version = "0.11", features = ["http-proto", "reqwest-client"], optional = true }
-
-prometheus = { version = "0.13", optional = true }
 
 [dev-dependencies]
 regex = "1"
 clap = { version = "4.0.10", features = ["derive"] }
+test-log = { version = "0.2.10", default-features = false, features = ["trace"] }
 
 [build-dependencies]
 weld-codegen = { version = "0.5.0", path = "../codegen" }

--- a/rpc-rs/Cargo.toml
+++ b/rpc-rs/Cargo.toml
@@ -70,4 +70,4 @@ clap = { version = "4.0.22", features = ["derive"] }
 test-log = { version = "0.2.10", default-features = false, features = ["trace"] }
 
 [build-dependencies]
-weld-codegen = { version = "0.5.1", path = "../codegen" }
+weld-codegen = { version = "0.6.0", path = "../codegen" }

--- a/rpc-rs/Makefile
+++ b/rpc-rs/Makefile
@@ -21,7 +21,7 @@ test::
 	docker stop wasmbus-rpc-test
 else
 test::
-	cargo test -- --nocapture
+	WASMBUS_RPC_TIMEOUT_MS=4000 cargo test -- --nocapture
 	cargo clippy --all-features --all-targets
 	rustfmt --edition 2021 --check src/*.rs
 endif

--- a/rpc-rs/examples/sub.rs
+++ b/rpc-rs/examples/sub.rs
@@ -8,14 +8,14 @@ use wasmbus_rpc::rpc_client::RpcClient;
 
 /// RpcClient test CLI for connection and subscription
 #[derive(Parser)]
-#[clap(version, about, long_about = None)]
+#[command(version, about, long_about = None)]
 struct Args {
     /// Nats uri. Defaults to 'nats://127.0.0.1:4222'
-    #[clap(short, long)]
+    #[arg(short, long)]
     nats: Option<String>,
 
     /// Subject (topic)
-    #[clap(value_parser)]
+    #[arg(value_parser)]
     subject: String,
 }
 

--- a/rpc-rs/src/cbor.rs
+++ b/rpc-rs/src/cbor.rs
@@ -192,13 +192,10 @@ pub struct Encoder<W: Write> {
 }
 
 pub fn vec_encoder(header: bool) -> Encoder<Vec<u8>> {
-    let buf = if header {
-        let mut buf = Vec::new();
+    let mut buf = Vec::new();
+    if header {
         crate::common::MessageFormat::Cbor.write_header(&mut buf).unwrap();
-        buf
-    } else {
-        Vec::new()
-    };
+    }
     Encoder { inner: minicbor::Encoder::new(buf) }
 }
 

--- a/rpc-rs/src/chunkify.rs
+++ b/rpc-rs/src/chunkify.rs
@@ -19,22 +19,18 @@
 
 use std::{
     collections::HashMap,
-    io::Read,
     sync::{Arc, RwLock},
 };
 
-use nats::{
-    jetstream::JetStream,
+use async_nats::jetstream::{
+    self,
     object_store::{Config, ObjectStore},
-    JetStreamOptions,
+    Context,
 };
 use once_cell::sync::OnceCell;
 use tracing::{debug, error, instrument};
 
-use crate::{
-    error::{RpcError, RpcResult},
-    provider_main::get_host_bridge,
-};
+use crate::error::{RpcError, RpcResult};
 
 /// Maximum size of a message payload before it will be chunked
 /// Nats currently uses 128kb chunk size so this should be at least 128KB
@@ -46,7 +42,7 @@ pub(crate) fn needs_chunking(payload_size: usize) -> bool {
 }
 
 /// map from lattice to ObjectStore - includes nats client connection
-type JsMap = HashMap<String, JetStream>;
+type JsMap = HashMap<String, Context>;
 
 fn jetstream_map() -> Arc<RwLock<JsMap>> {
     static INSTANCE: OnceCell<Arc<RwLock<JsMap>>> = OnceCell::new();
@@ -64,21 +60,23 @@ pub(crate) fn shutdown() {
 #[derive(Clone)]
 pub struct ChunkEndpoint {
     lattice: String,
-    js: JetStream,
+    js: Context,
 }
 
 impl ChunkEndpoint {
-    pub fn new(lattice: String, js: JetStream) -> Self {
+    pub fn new(lattice: String, js: Context) -> Self {
         ChunkEndpoint { lattice, js }
     }
 
     /// load the message after de-chunking
     #[instrument(level = "trace", skip(self))]
-    pub fn get_unchunkified(&self, inv_id: &str) -> RpcResult<Vec<u8>> {
+    pub async fn get_unchunkified(&self, inv_id: &str) -> RpcResult<Vec<u8>> {
+        use futures::TryFutureExt as _;
+        use tokio::io::AsyncReadExt as _;
         let mut result = Vec::new();
-        let store = self.create_or_reuse_store()?;
+        let store = self.create_or_reuse_store().await?;
         debug!(invocation_id = %inv_id, "chunkify starting to receive");
-        let mut obj = store.get(inv_id).map_err(|e| {
+        let mut obj = store.get(inv_id).await.map_err(|e| {
             RpcError::Nats(format!(
                 "error starting to receive chunked stream for inv {}:{}",
                 inv_id, e
@@ -90,8 +88,9 @@ impl ChunkEndpoint {
                 "error receiving chunked stream for inv {}:{}",
                 inv_id, e
             ))
-        })?;
-        if let Err(e) = store.delete(inv_id) {
+        })
+        .await?;
+        if let Err(e) = store.delete(inv_id).await {
             // not deleting will be a non-fatal error for the receiver,
             // if all the bytes have been received
             error!(invocation_id = %inv_id, error = %e, "deleting chunks for inv");
@@ -100,18 +99,23 @@ impl ChunkEndpoint {
     }
 
     /// load response after de-chunking
-    pub fn get_unchunkified_response(&self, inv_id: &str) -> RpcResult<Vec<u8>> {
+    pub async fn get_unchunkified_response(&self, inv_id: &str) -> RpcResult<Vec<u8>> {
         // responses are stored in the object store with '-r' suffix on the object name
-        self.get_unchunkified(&format!("{}-r", inv_id))
+        self.get_unchunkified(&format!("{}-r", inv_id)).await
     }
 
     /// chunkify a message
     #[instrument(level = "trace", skip(self, bytes))]
-    pub fn chunkify(&self, inv_id: &str, bytes: &mut impl Read) -> RpcResult<()> {
-        let store = self.create_or_reuse_store()?;
+    pub async fn chunkify(
+        &self,
+        inv_id: &str,
+        mut bytes: (impl tokio::io::AsyncRead + std::marker::Unpin),
+    ) -> RpcResult<()> {
+        let store = self.create_or_reuse_store().await?;
         debug!(invocation_id = %inv_id, "chunkify starting to send");
         let info = store
-            .put(inv_id, bytes)
+            .put(inv_id, &mut bytes)
+            .await
             .map_err(|e| RpcError::Nats(format!("writing chunkified for {}: {}", inv_id, e)))?;
         debug!(?info, invocation_id = %inv_id, "chunkify completed writing");
 
@@ -119,19 +123,27 @@ impl ChunkEndpoint {
     }
 
     /// chunkify a portion of a response
-    pub fn chunkify_response(&self, inv_id: &str, bytes: &mut impl Read) -> Result<(), RpcError> {
-        self.chunkify(&format!("{}-r", inv_id), bytes)
+    pub async fn chunkify_response(
+        &self,
+        inv_id: &str,
+        bytes: &mut (impl tokio::io::AsyncRead + std::marker::Unpin),
+    ) -> Result<(), RpcError> {
+        self.chunkify(&format!("{}-r", inv_id), bytes).await
     }
 
-    fn create_or_reuse_store(&self) -> RpcResult<ObjectStore> {
-        let store = match self.js.object_store(&self.lattice) {
+    async fn create_or_reuse_store(&self) -> RpcResult<ObjectStore> {
+        let store = match self.js.get_object_store(&self.lattice).await {
             Ok(store) => store,
             Err(_) => self
                 .js
-                .create_object_store(&Config {
+                .create_object_store(Config {
                     bucket: self.lattice.clone(),
-                    ..Default::default()
+                    description: None,
+                    max_age: Default::default(),
+                    storage: Default::default(),
+                    num_replicas: 0, //..Default::default()
                 })
+                .await
                 .map_err(|e| RpcError::Nats(format!("Failed to create store: {}", &e)))?,
         };
         Ok(store)
@@ -140,24 +152,28 @@ impl ChunkEndpoint {
 
 pub(crate) fn chunkify_endpoint(
     domain: Option<String>,
+    nc: async_nats::Client,
     lattice: String,
 ) -> RpcResult<ChunkEndpoint> {
-    let js = connect_js(domain, &lattice)?;
+    let js = connect_js(domain, nc, &lattice)?;
     Ok(ChunkEndpoint::new(lattice, js))
 }
 
-pub(crate) fn connect_js(domain: Option<String>, lattice_prefix: &str) -> RpcResult<JetStream> {
+pub(crate) fn connect_js(
+    domain: Option<String>,
+    nc: async_nats::Client,
+    lattice_prefix: &str,
+) -> RpcResult<Context> {
     let map = jetstream_map();
     let mut _w = map.write().unwrap(); // panics if lock is poisioned
-    let js: JetStream = if let Some(js) = _w.get(lattice_prefix) {
+    let js: Context = if let Some(js) = _w.get(lattice_prefix) {
         js.clone()
     } else {
-        let nc = get_host_bridge().new_sync_client()?;
-        let mut jsoptions = JetStreamOptions::new();
-        if let Some(domain) = domain {
-            jsoptions = jsoptions.domain(domain.as_str());
-        }
-        let js = JetStream::new(nc, jsoptions);
+        let js = if let Some(domain) = domain {
+            jetstream::with_domain(nc, domain)
+        } else {
+            jetstream::new(nc)
+        };
         _w.insert(lattice_prefix.to_string(), js.clone());
         js
     };

--- a/rpc-rs/src/chunkify.rs
+++ b/rpc-rs/src/chunkify.rs
@@ -138,10 +138,7 @@ impl ChunkEndpoint {
                 .js
                 .create_object_store(Config {
                     bucket: self.lattice.clone(),
-                    description: None,
-                    max_age: Default::default(),
-                    storage: Default::default(),
-                    num_replicas: 0, //..Default::default()
+                    ..Default::default()
                 })
                 .await
                 .map_err(|e| RpcError::Nats(format!("Failed to create store: {}", &e)))?,

--- a/rpc-rs/src/chunkify.rs
+++ b/rpc-rs/src/chunkify.rs
@@ -34,7 +34,7 @@ use crate::error::{RpcError, RpcResult};
 
 /// Maximum size of a message payload before it will be chunked
 /// Nats currently uses 128kb chunk size so this should be at least 128KB
-const CHUNK_THRESHOLD_BYTES: usize = 1024 * 700; // 700KB
+const CHUNK_THRESHOLD_BYTES: usize = 1024 * 900; // 900KB
 
 /// check if message payload needs to be chunked
 pub(crate) fn needs_chunking(payload_size: usize) -> bool {

--- a/rpc-rs/src/otel.rs
+++ b/rpc-rs/src/otel.rs
@@ -99,16 +99,7 @@ impl OtelHeaderInjector {
 
 impl Injector for OtelHeaderInjector {
     fn set(&mut self, key: &str, value: String) {
-        // NOTE: Because the underlying headers are an http header, we are going to escape any
-        // unicode values and non-printable ASCII chars, which sounds better than just silently
-        // ignoring or using an empty string. Unfortunately this adds an extra allocation that is
-        // probably ok for now as it is freed at the end, but I prefer telemetry stuff to be as
-        // little overhead as possible. If anyone has a better idea of how to handle this, please PR
-        // it in
-        // SAFETY: All chars escaped above
-        let key = key.escape_default().to_string();
-        let value = value.escape_default().to_string();
-        self.inner.insert(key.as_str(), value.as_str());
+        self.inner.insert(key, value.as_ref());
     }
 }
 

--- a/rpc-rs/src/otel.rs
+++ b/rpc-rs/src/otel.rs
@@ -18,29 +18,41 @@ lazy_static::lazy_static! {
 #[derive(Debug)]
 pub struct OtelHeaderExtractor<'a> {
     inner: &'a HeaderMap,
+    keys: Vec<String>,
 }
 
 impl<'a> OtelHeaderExtractor<'a> {
     /// Creates a new extractor using the given [`HeaderMap`]
     pub fn new(headers: &'a HeaderMap) -> Self {
-        OtelHeaderExtractor { inner: headers }
+        OtelHeaderExtractor {
+            inner: headers,
+            keys: headers
+                .iter()
+                .map(|(k, _)| String::from_utf8_lossy(k.as_ref()).to_string())
+                .collect(),
+        }
     }
 
     /// Creates a new extractor using the given message
     pub fn new_from_message(msg: &'a async_nats::Message) -> Self {
+        let inner = msg.headers.as_ref().unwrap_or(&EMPTY_HEADERS);
         OtelHeaderExtractor {
-            inner: msg.headers.as_ref().unwrap_or(&EMPTY_HEADERS),
+            inner,
+            keys: inner
+                .iter()
+                .map(|(k, _)| String::from_utf8_lossy(k.as_ref()).to_string())
+                .collect(),
         }
     }
 }
 
 impl<'a> Extractor for OtelHeaderExtractor<'a> {
     fn get(&self, key: &str) -> Option<&str> {
-        self.inner.get(key).and_then(|s| s.to_str().ok())
+        self.inner.get(key).and_then(|s| s.iter().next().map(|s| s.as_str()))
     }
 
     fn keys(&self) -> Vec<&str> {
-        self.inner.keys().map(|s| s.as_str()).collect()
+        self.keys.iter().map(|k| k.as_str()).collect()
     }
 }
 
@@ -93,13 +105,10 @@ impl Injector for OtelHeaderInjector {
         // probably ok for now as it is freed at the end, but I prefer telemetry stuff to be as
         // little overhead as possible. If anyone has a better idea of how to handle this, please PR
         // it in
-        let header_name = key.escape_default().to_string().into_bytes();
-        let escaped = value.escape_default().to_string().into_bytes();
         // SAFETY: All chars escaped above
-        self.inner.insert(
-            async_nats::header::HeaderName::from_bytes(&header_name).unwrap(),
-            async_nats::HeaderValue::from_bytes(&escaped).unwrap(),
-        );
+        let key = key.escape_default().to_string();
+        let value = value.escape_default().to_string();
+        self.inner.insert(key.as_str(), value.as_str());
     }
 }
 

--- a/rpc-rs/src/provider.rs
+++ b/rpc-rs/src/provider.rs
@@ -390,9 +390,9 @@ impl HostBridge {
                                     #[cfg(feature = "prometheus")]
                                     {
                                         if let Some(len) = inv.content_length {
-                                            self.rpc_client.stats.rpc_recv_bytes.inc_by(len);
+                                            this.rpc_client.stats.rpc_recv_bytes.inc_by(len);
                                         }
-                                        self.rpc_client.stats.rpc_recv.inc();
+                                        this.rpc_client.stats.rpc_recv.inc();
                                     }
                                     let inv_id = inv.id.clone();
                                     let resp = match this.handle_rpc(provider.clone(), inv).in_current_span().await {
@@ -511,7 +511,7 @@ impl HostBridge {
                 // Backwards compatibility - if no host (or payload) is supplied, default
                 // to shutting down unconditionally
                 if shutmsg.host_id.is_empty() {
-                    warn!("Please upgrade your wasmcloud host to >= 0.58.3 if you use lattices with multiple hosts.")
+                    warn!("Please upgrade your wasmcloud host to >= 0.59.0 if you use lattices with multiple hosts.")
                 }
                 if shutmsg.host_id == self.host_data.host_id || shutmsg.host_id.is_empty() {
                     info!("Received termination signal and stopping");

--- a/rpc-rs/src/provider.rs
+++ b/rpc-rs/src/provider.rs
@@ -159,7 +159,7 @@ impl HostBridge {
         let rpc_client = RpcClient::new_client(
             nats,
             host_data.host_id.clone(),
-            host_data.default_rpc_timeout_ms.map(|ms| Duration::from_millis(ms as u64)),
+            host_data.default_rpc_timeout_ms.map(Duration::from_millis),
             key.clone(),
         );
 
@@ -710,7 +710,7 @@ impl<'send> ProviderTransport<'send> {
             bridge
                 .host_data
                 .default_rpc_timeout_ms
-                .map(|t| Duration::from_millis(t as u64))
+                .map(Duration::from_millis)
                 .unwrap_or(DEFAULT_RPC_TIMEOUT_MILLIS)
         }));
         Self { bridge, ld, timeout }
@@ -736,7 +736,7 @@ impl<'send> Transport for ProviderTransport<'send> {
                 self.bridge
                     .host_data
                     .default_rpc_timeout_ms
-                    .map(|t| Duration::from_millis(t as u64))
+                    .map(Duration::from_millis)
                     .unwrap_or(DEFAULT_RPC_TIMEOUT_MILLIS)
             }
         };

--- a/rpc-rs/src/provider.rs
+++ b/rpc-rs/src/provider.rs
@@ -357,10 +357,7 @@ impl HostBridge {
                         break;
                     },
                     nats_msg = sub.next() => {
-                        let msg = match nats_msg {
-                            None => break,
-                            Some(msg) => msg
-                        };
+                        let msg = if let Some(msg) = nats_msg { msg } else { break; };
                         let this = this.clone();
                         let provider = provider.clone();
                         let lattice = lattice.clone();
@@ -380,7 +377,6 @@ impl HostBridge {
                             crate::otel::attach_span_context(&msg);
                             match crate::common::deserialize::<Invocation>(&msg.payload) {
                                 Ok(inv) => {
-                                    let inv_id = inv.id.clone();
                                     let current = tracing::Span::current();
                                     current.record("operation", &tracing::field::display(&inv.operation));
                                     current.record("lattice_id", &tracing::field::display(&lattice));
@@ -391,13 +387,19 @@ impl HostBridge {
                                     current.record("contract_id", &tracing::field::display(&inv.target.contract_id));
                                     current.record("link_name", &tracing::field::display(&inv.target.link_name));
                                     current.record("payload_size", &tracing::field::display(&inv.content_length.unwrap_or_default()));
-                                    let provider = provider.clone();
-                                    let resp = match this.handle_rpc(provider, inv).in_current_span().await {
+                                    #[cfg(feature = "prometheus")]
+                                    {
+                                        if let Some(len) = inv.content_length {
+                                            self.rpc_client.stats.rpc_recv_bytes.inc_by(len);
+                                        }
+                                        self.rpc_client.stats.rpc_recv.inc();
+                                    }
+                                    let inv_id = inv.id.clone();
+                                    let resp = match this.handle_rpc(provider.clone(), inv).in_current_span().await {
                                         Err(error) => {
-                                            error!(
-                                                %error,
-                                                "Invocation failed"
-                                            );
+                                            error!(%error, "Invocation failed");
+                                            #[cfg(feature = "prometheus")]
+                                            this.rpc_client.stats.rpc_recv_err.inc();
                                             InvocationResponse{
                                                 invocation_id: inv_id,
                                                 error: Some(error.to_string()),
@@ -405,6 +407,8 @@ impl HostBridge {
                                             }
                                         },
                                         Ok(bytes) => {
+                                            #[cfg(feature = "prometheus")]
+                                            this.rpc_client.stats.rpc_recv_resp_bytes.inc_by(bytes.len() as u64);
                                             InvocationResponse{
                                                 invocation_id: inv_id,
                                                 content_length: Some(bytes.len() as u64),
@@ -416,7 +420,7 @@ impl HostBridge {
                                     if let Some(reply) = msg.reply {
                                         // send reply
                                         if let Err(error) = this.rpc_client()
-                                        .publish_invocation_response(reply, resp, &lattice).in_current_span().await {
+                                            .publish_invocation_response(reply, resp, &lattice).in_current_span().await {
                                             error!(%error, "rpc sending response");
                                         }
                                     }
@@ -431,7 +435,7 @@ impl HostBridge {
                                             },
                                             &lattice
                                         ).in_current_span().await {
-                                            error!(error = %e, "unable to publish error message to invocation response");
+                                            error!(error = %e, "unable to publish invocation response error");
                                         }
                                     }
                                 }
@@ -459,8 +463,7 @@ impl HostBridge {
         let inv = self.rpc_client().dechunk(inv, lattice).await?;
         let (inv, claims) = self.rpc_client.validate_invocation(inv).await?;
         self.validate_provider_invocation(&inv, &claims).await?;
-
-        let resp = provider
+        provider
             .dispatch(
                 &Context {
                     actor: Some(inv.origin.public_key.clone()),
@@ -472,13 +475,7 @@ impl HostBridge {
                 },
             )
             .instrument(tracing::debug_span!("dispatch", public_key = %inv.origin.public_key, operation = %inv.operation))
-            .await;
-        #[cfg(feature = "prometheus")]
-        match &resp {
-            Err(_) => self.rpc_client.stats.rpc_recv_err.inc(),
-            Ok(vec) => self.rpc_client.stats.rpc_recv_resp_bytes.inc_by(vec.len() as u64),
-        }
-        resp
+            .await
     }
 
     async fn subscribe_shutdown<P>(
@@ -513,16 +510,19 @@ impl HostBridge {
                 let shutmsg: ShutdownMessage = serde_json::from_slice(&payload).unwrap_or_default();
                 // Backwards compatibility - if no host (or payload) is supplied, default
                 // to shutting down unconditionally
+                if shutmsg.host_id.is_empty() {
+                    warn!("Please upgrade your wasmcloud host to >= 0.58.3 if you use lattices with multiple hosts.")
+                }
                 if shutmsg.host_id == self.host_data.host_id || shutmsg.host_id.is_empty() {
                     info!("Received termination signal and stopping");
                     // Tell provider to shutdown - before we shut down nats subscriptions,
                     // in case it needs to do any message passing during shutdown
-                    if let Err(e) = provider.shutdown().await {
-                        error!(error = %e, "got error during provider shutdown processing");
+                    if let Err(error) = provider.shutdown().await {
+                        error!(%error, "got error during provider shutdown processing");
                     }
                     let data = b"shutting down".to_vec();
-                    if let Err(e) = self.rpc_client().publish(reply_to, data).await {
-                        error!(error = %e, "failed to send shutdown ack");
+                    if let Err(error) = self.rpc_client().publish(reply_to, data).await {
+                        warn!(%error, "failed to send shutdown ack");
                     }
                     // unsubscribe from shutdown topic
                     let _ = sub.unsubscribe().await;
@@ -639,16 +639,13 @@ impl HostBridge {
         let this = self.clone();
         process_until_quit!(sub, quit, msg, {
             let arg = HealthCheckRequest {};
-            let resp = match provider.health_request(&arg).await {
-                Ok(resp) => resp,
-                Err(e) => {
-                    error!(error = %e, "error generating health check response");
-                    HealthCheckResponse {
-                        healthy: false,
-                        message: Some(e.to_string()),
-                    }
+            let resp = provider.health_request(&arg).await.unwrap_or_else(|e| {
+                error!(error = %e, "error generating health check response");
+                HealthCheckResponse {
+                    healthy: false,
+                    message: Some(e.to_string()),
                 }
-            };
+            });
             let buf = if this.host_data.is_test() {
                 Ok(serde_json::to_vec(&resp).unwrap())
             } else {

--- a/rpc-rs/src/provider_main.rs
+++ b/rpc-rs/src/provider_main.rs
@@ -68,14 +68,11 @@ static BRIDGE: OnceCell<HostBridge> = OnceCell::new();
 
 // this may be called any time after initialization
 pub fn get_host_bridge() -> &'static HostBridge {
-    match BRIDGE.get() {
-        Some(b) => b,
-        None => {
-            // initialized first thing, so this shouldn't happen
-            eprintln!("BRIDGE not initialized");
-            panic!();
-        }
-    }
+    BRIDGE.get().unwrap_or_else(|| {
+        // initialized first thing, so this shouldn't happen
+        eprintln!("BRIDGE not initialized");
+        panic!();
+    })
 }
 
 #[doc(hidden)]
@@ -370,11 +367,8 @@ fn get_log_layer(structured_logging_enabled: bool) -> impl Layer<Layered<EnvFilt
 }
 
 fn get_env_filter() -> EnvFilter {
-    match EnvFilter::try_from_default_env() {
-        Ok(f) => f,
-        Err(e) => {
-            eprintln!("RUST_LOG was not set or the given directive was invalid: {:?}\nDefaulting logger to `info` level", e);
-            EnvFilter::default().add_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
-        }
-    }
+    EnvFilter::try_from_default_env().unwrap_or_else(|e| {
+        eprintln!("RUST_LOG was not set or the given directive was invalid: {:?}\nDefaulting logger to `info` level", e);
+        EnvFilter::default().add_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
+    })
 }

--- a/rpc-rs/src/provider_main.rs
+++ b/rpc-rs/src/provider_main.rs
@@ -75,6 +75,12 @@ pub fn get_host_bridge() -> &'static HostBridge {
     })
 }
 
+// like get_host_bridge but doesn't panic if it's not initialized
+// This could be a valid condition if RpcClient is used outside capability providers
+pub fn get_host_bridge_safe() -> Option<&'static HostBridge> {
+    BRIDGE.get()
+}
+
 #[doc(hidden)]
 /// Sets the bridge, return Err if it was already set
 pub(crate) fn set_host_bridge(hb: HostBridge) -> Result<(), ()> {

--- a/rpc-rs/src/provider_main.rs
+++ b/rpc-rs/src/provider_main.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use once_cell::sync::OnceCell;
 #[cfg(feature = "otel")]
 use opentelemetry::sdk::{
-    trace::{self, IdGenerator, Sampler},
+    trace::{self, RandomIdGenerator, Sampler},
     Resource,
 };
 #[cfg(feature = "otel")]
@@ -325,7 +325,7 @@ fn configure_tracing(provider_name: String, structured_logging_enabled: bool) {
             .with_trace_config(
                 trace::config()
                     .with_sampler(Sampler::AlwaysOn)
-                    .with_id_generator(IdGenerator::default())
+                    .with_id_generator(RandomIdGenerator::default())
                     .with_max_events_per_span(64)
                     .with_max_attributes_per_span(16)
                     .with_max_events_per_span(16)

--- a/rpc-rs/src/rpc_client.rs
+++ b/rpc-rs/src/rpc_client.rs
@@ -623,8 +623,8 @@ pub fn with_connection_event_logging(
     use async_nats::Event;
     opts.event_callback(|event| async move {
         match event {
-            Event::Disconnect => warn!("nats client disconnected"),
-            Event::Reconnect => info!("nats client reconnected"),
+            Event::Disconnected => warn!("nats client disconnected"),
+            Event::Connected => info!("nats client connected"),
             Event::ClientError(err) => error!("nats client error: '{:?}'", err),
             Event::ServerError(err) => error!("nats server error: '{:?}'", err),
             Event::SlowConsumer(val) => warn!("nats slow consumer detected ({})", val),

--- a/rpc-rs/src/timestamp.rs
+++ b/rpc-rs/src/timestamp.rs
@@ -110,7 +110,7 @@ impl From<SystemTime> for Timestamp {
             .expect("system time before Unix epoch");
         Timestamp {
             sec: d.as_secs() as i64,
-            nsec: d.subsec_nanos() as u32,
+            nsec: d.subsec_nanos(),
         }
     }
 }

--- a/rpc-rs/tests/nats_sub.rs
+++ b/rpc-rs/tests/nats_sub.rs
@@ -4,7 +4,6 @@
 use std::{str::FromStr, sync::Arc, time::Duration};
 
 use test_log::test;
-use tracing::error;
 use wascap::prelude::KeyPair;
 use wasmbus_rpc::{
     error::{RpcError, RpcResult},
@@ -12,7 +11,6 @@ use wasmbus_rpc::{
 };
 
 const ONE_SEC: Duration = Duration::from_secs(1);
-const THREE_SEC: Duration = Duration::from_secs(3);
 const FIVE_SEC: Duration = Duration::from_secs(5);
 const TEST_NATS_ADDR: &str = "nats://127.0.0.1:4222";
 const HOST_ID: &str = "HOST_test_nats_sub";
@@ -177,16 +175,15 @@ async fn test_message_size() -> Result<(), Box<dyn std::error::Error>> {
         // don't abuse it by running this test with very large sizes
         //
         // The last size must be 1 to signal to listen_bin to exit
-        &[10u32, 25, 100, 200, 500, 1000, 8000, 1]
+        &[10u32, 100, 200, 500, 1000, 8000, 1]
     } else {
         // The last size must be 1 to signal to listen_bin to exit
-        &[10u32, 25, 500, 10_000, 800_000, 1_000_000, 1_200_000, 1]
+        &[10u32, 25, 500, 10_000, 800_000, 1_000_000, 1]
     };
     for size in test_sizes.iter() {
         let mut data = Vec::with_capacity(*size as usize);
         data.resize(*size as usize, 255u8);
-        let resp = match tokio::time::timeout(FIVE_SEC, sender.request(topic.clone(), data)).await
-        {
+        let resp = match tokio::time::timeout(FIVE_SEC, sender.request(topic.clone(), data)).await {
             Ok(Ok(result)) => result,
             Ok(Err(rpc_err)) => {
                 eprintln!("send error on msg size {}: {}", *size, rpc_err);

--- a/rpc-rs/tests/nats_sub.rs
+++ b/rpc-rs/tests/nats_sub.rs
@@ -17,7 +17,7 @@ const TEST_NATS_ADDR: &str = "nats://127.0.0.1:4222";
 const HOST_ID: &str = "HOST_test_nats_sub";
 
 fn nats_url() -> String {
-    std::env::var("NATS_URL").unwrap_or_else(|| TEST_NATS_ADDR.into())
+    std::env::var("NATS_URL").unwrap_or_else(|_| TEST_NATS_ADDR.into())
 }
 
 fn is_demo() -> bool {

--- a/rpc-rs/tests/nats_sub.rs
+++ b/rpc-rs/tests/nats_sub.rs
@@ -17,11 +17,7 @@ const TEST_NATS_ADDR: &str = "nats://127.0.0.1:4222";
 const HOST_ID: &str = "HOST_test_nats_sub";
 
 fn nats_url() -> String {
-    if let Ok(addr) = std::env::var("NATS_URL") {
-        addr
-    } else {
-        TEST_NATS_ADDR.to_string()
-    }
+    std::env::var("NATS_URL").unwrap_or_else(|| TEST_NATS_ADDR.into())
 }
 
 fn is_demo() -> bool {


### PR DESCRIPTION
Signed-off-by: stevelr <steve@cosmonic.com>

updates headers api to async-nats 0.20
replaces sync nats with async nats objectstore

This is a draft PR. 
https://github.com/nats-io/nats.rs/pull/655 must be merged first.