### PR TITLE
Only shut down provider if owning host sends shutdown message

### DIFF
--- a/rpc-rs/Cargo.toml
+++ b/rpc-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmbus-rpc"
-version = "0.10.1"
+version = "0.10.2"
 authors = [ "wasmcloud Team" ]
 license = "Apache-2.0"
 description = "Runtime library for actors and capability providers"
@@ -50,8 +50,8 @@ bigdecimal = { version = "0.3", optional = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
-async-nats = "0.18.0"
-nats = "0.22.0"
+async-nats = "0.19.0"
+nats = "0.23.0"
 nkeys = "0.2"
 once_cell = "1.8"
 uuid = { version = "1.0", features = ["v4", "serde"] }
@@ -69,7 +69,7 @@ prometheus = { version = "0.13", optional = true }
 
 [dev-dependencies]
 regex = "1"
-clap = { version = "3.2.5", features = ["derive"] }
+clap = { version = "4.0.20", features = ["derive"] }
 
 [build-dependencies]
 weld-codegen = { version = "0.5.0", path = "../codegen" }

--- a/rpc-rs/Cargo.toml
+++ b/rpc-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmbus-rpc"
-version = "0.10.2"
+version = "0.11.0"
 authors = [ "wasmcloud Team" ]
 license = "Apache-2.0"
 description = "Runtime library for actors and capability providers"


### PR DESCRIPTION
This code will check the shutdown message payload and if the host on said payload matches, the capability provider will terminate. This prevents the wasmCloud bug that terminates all instances of a provider rather than just the one on the host.

if there's a problem where the termination message doesn't contain the new payload, the provider will not shutdown (because it won't match the source host with the parent host).

See https://github.com/wasmCloud/wasmcloud-otp/pull/494 for the host side of this