### PR TITLE
Downgraded opentelemetry dependencies to remove protoc

### DIFF
--- a/.github/workflows/wasmbus-rpc.yml
+++ b/.github/workflows/wasmbus-rpc.yml
@@ -26,8 +26,6 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt, clippy
-      - name: install_protoc
-        run: sudo apt-get install -y protobuf-compiler
       - name: run_all_tests_clippy_fmt
         working-directory: ${{ env.working-directory }}
         run: make test

--- a/rpc-rs/Cargo.toml
+++ b/rpc-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmbus-rpc"
-version = "0.11.0"
+version = "0.11.1"
 authors = [ "wasmcloud Team" ]
 license = "Apache-2.0"
 description = "Runtime library for actors and capability providers"
@@ -53,12 +53,12 @@ futures = "0.3"
 lazy_static = "1.4"
 nkeys = "0.2"
 once_cell = "1.8"
-opentelemetry = { version = "0.18", features = ["rt-tokio"], optional = true }
-opentelemetry-otlp = { version = "0.11", features = ["http-proto", "reqwest-client"], optional = true }
+opentelemetry = { version = "0.17", features = ["rt-tokio"], optional = true }
+opentelemetry-otlp = { version = "0.10", features = ["http-proto", "reqwest-client"], optional = true }
 prometheus = { version = "0.13", optional = true }
 sha2 = "0.10.2"
 tokio = { version = "1", features = ["full"] }
-tracing-opentelemetry = { version = "0.18", optional = true }
+tracing-opentelemetry = { version = "0.17", optional = true }
 tracing-subscriber = { version = "0.3.7", features = ["env-filter", "json"] }
 uuid = { version = "1.0", features = ["v4", "serde"] }
 wascap = "0.8.0"

--- a/rpc-rs/src/provider_main.rs
+++ b/rpc-rs/src/provider_main.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use once_cell::sync::OnceCell;
 #[cfg(feature = "otel")]
 use opentelemetry::sdk::{
-    trace::{self, RandomIdGenerator, Sampler},
+    trace::{self, IdGenerator, Sampler},
     Resource,
 };
 #[cfg(feature = "otel")]
@@ -328,7 +328,7 @@ fn configure_tracing(provider_name: String, structured_logging_enabled: bool) {
             .with_trace_config(
                 trace::config()
                     .with_sampler(Sampler::AlwaysOn)
-                    .with_id_generator(RandomIdGenerator::default())
+                    .with_id_generator(IdGenerator::default())
                     .with_max_events_per_span(64)
                     .with_max_attributes_per_span(16)
                     .with_max_events_per_span(16)


### PR DESCRIPTION
This PR downgrades our opentelemetry dependencies in wasmbus-rpc to remove the requirement that `protoc` be installed on machines where we build wasmbus-rpc for non-wasm32 targets. 

I thought I was okay with this change when it came in a few days ago, however, requiring `protoc` for our capability providers that use OTEL is different than requiring `protoc` for `wash`, where `cargo install wash-cli` is a reasonable install path. I don't want people who are installing `wash` to need `protoc`, just a Rust installation.

Because this is a patch everything should get this update without much effort.

I could use some help with opening an issue in https://github.com/open-telemetry/opentelemetry-rust/issues because admittedly I don't know exactly what kinds of things I can present as evidence other than the fact that it broke our thing and we don't use protoc and we shouldn't have to.