### PR TITLE
fix: go code gen array alloc error

### DIFF
--- a/codegen/src/codegen_go.rs
+++ b/codegen/src/codegen_go.rs
@@ -1660,7 +1660,7 @@ impl<'model> GoCodeGen<'model> {
                         }}
                        	{}
                         if err != nil {{ return make([]{},0),err }}
-                        val := make([]{}, size)
+                        val := make([]{}, 0, size)
                         for i := uint32(0); i < size; i++ {{
                            item,err := {}
                            if err != nil {{ return val, err }}

--- a/codegen/src/codegen_go.rs
+++ b/codegen/src/codegen_go.rs
@@ -1629,7 +1629,7 @@ impl<'model> GoCodeGen<'model> {
                         }}
                        	{}
                         if err != nil {{ return make([]{}, 0 ), err }}
-                        val := make([]{}, size)
+                        val := make([]{}, 0, size)
                         for i := uint32(0); i < size; i++ {{
                            item,err := {}
                            if err != nil {{ return val, err }}


### PR DESCRIPTION
When using make in go, we can use`make([]type, length)`(this is equal to `make([]type, length, length)`) or `make([]type, length, capacity)`. For example, `make([]type, 10, 100)` creating a slice structure with length 10 and a capacity 100 with the first 10 elements initialized to zero value.

The current code makes the slice length doubled and leaving the first half zero value.