### PR TITLE
Use `data-encoding` for base64 decoding

### DIFF
--- a/rpc-rs/Cargo.toml
+++ b/rpc-rs/Cargo.toml
@@ -24,9 +24,9 @@ otel = ["opentelemetry", "tracing-opentelemetry", "opentelemetry-otlp"]
 
 [dependencies]
 async-trait = "0.1"
-base64 = "0.13"
 bytes = "1.1.0"
 cfg-if = "1.0"
+data-encoding = "2.3"
 minicbor = { version = "0.17.1", features = ["std"] }
 rmp-serde = "1.1.0"
 serde_bytes = "0.11"
@@ -48,7 +48,6 @@ bigdecimal = { version = "0.3", optional = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 async-nats = "0.23.0"
 atty = "0.2"
-data-encoding = "2.3"
 futures = "0.3"
 lazy_static = "1.4"
 nkeys = "0.2"

--- a/rpc-rs/src/provider_main.rs
+++ b/rpc-rs/src/provider_main.rs
@@ -242,7 +242,7 @@ pub fn _load_host_data() -> Result<HostData, RpcError> {
             "stdin is empty - expecting host data configuration".to_string(),
         ));
     }
-    let bytes = base64::decode(buffer.as_bytes()).map_err(|e| {
+    let bytes = data_encoding::BASE64.decode(buffer.as_bytes()).map_err(|e| {
         RpcError::Rpc(format!(
             "host data configuration passed through stdin has invalid encoding (expected base64): \
              {}",


### PR DESCRIPTION
The crate is already in use and provides base64 decoding.

Signed-off-by: Constantin Nickel <constantin.nickel@gmail.com>