### PR TITLE
feat: allow for overriding weld cache dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains
 - [codegen](https://github.com/wasmCloud/weld/blob/main/codegen/README.md) code generators to turn smithy models into target language libraries. Currently supported target languages: Rust and Html (for documentation). We plan to implement more targets in the future.
 - [macros](https://github.com/wasmCloud/weld/blob/main/macros/README.md) derive macros for wasmCloud Rust projects. These are published as [wasmbus-macros](https://docs.rs/wasmbus-macros/), but they are not usually imported directly, but through wasmbus-rpc.
 - [wasmbus-rpc](https://docs.rs/wasmbus-rpc) the Rust library for wasmCloud actors and capability providers.
- 
+
 You can find wasmcloud-related interfaces defined with smithy IDL in [interfaces](https://github.com/wasmcloud/interfaces/) and [examples](https://github.com/wasmCloud/examples/tree/main/interface/).
 
 ## Smithy References and tools
@@ -14,4 +14,3 @@ You can find wasmcloud-related interfaces defined with smithy IDL in [interfaces
 - [IDL spec v1.0](https://awslabs.github.io/smithy/1.0/spec/core/idl.html)
 - [Visual Studio plugin](https://github.com/awslabs/smithy-vscode) (in the extension marketplace)
 - [Rust-atelier](https://github.com/johnstonskj/rust-atelier) rust smithy sdk that weld tools are built on
-  

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -8,3 +8,14 @@ The code generator can be invoked:
 - from the [`wash` cli](https://github.com/wasmcloud/wash)
 
 Documentation on how the code generator works, how to use it with wasmCloud, and how to extend it, can be found in the [developer documentation](https://wasmcloud.dev/interfaces/).
+
+## Environment Variables
+
+The following environment variables can be used to modify the operation of `codegen`:
+
+| Variable         | Default                                              | Example              | Description                                            |
+|------------------|------------------------------------------------------|----------------------|--------------------------------------------------------|
+| `WELD_CACHE_DIR` | [`$XDG_CACHE_DIR`/`$HOME/.cache`][directories-crate] | `/path/to/cache/dir` | Override cache directory used by `weld`                |
+| `SMITHY_CACHE`   | N/A                                                  | `NO_EXPIRE`          | Alter behavior (force enable) of the smithy file cache |
+
+[directories-crate]: https://crates.io/crates/directories

--- a/codegen/src/loader.rs
+++ b/codegen/src/loader.rs
@@ -19,6 +19,9 @@ const CACHED_FILE_MAX_AGE: Duration = Duration::from_secs(60 * 60 * 24); // one 
 const SMITHY_CACHE_ENV_VAR: &str = "SMITHY_CACHE";
 const SMITHY_CACHE_NO_EXPIRE: &str = "NO_EXPIRE";
 
+/// Name of ENV var that can be used to override weld cache directory
+const WELD_CACHE_DIR_ENV_VAR: &str = "WELD_CACHE_DIR";
+
 /// Load all model sources and merge into single model.
 /// - Sources may be a combination of files, directories, and urls.
 /// - Model files may be .smithy or .json
@@ -147,6 +150,11 @@ fn url_to_cache_path(url: &str) -> Result<PathBuf> {
 /// Locate the weld cache directory
 #[doc(hidden)]
 pub fn weld_cache_dir() -> Result<PathBuf> {
+    // Use weld cache dir override if present (ex. in CI environments)
+    if let Some(cache_dir) = std::env::var(WELD_CACHE_DIR_ENV_VAR) {
+        return Ok(cache_dir);
+    }
+
     let dirs = directories::BaseDirs::new()
         .ok_or_else(|| Error::Other("invalid home directory".to_string()))?;
     let weld_cache = dirs.cache_dir().join("smithy");


### PR DESCRIPTION
Allow overriding `weld` cache directory (so it can be controlled during CI and avoid situations where `$HOME` or `$XDG_CACHE_DIR` are not set)