### PR TITLE
make config_json available to providers

### DIFF
--- a/rpc-rs/src/document.rs
+++ b/rpc-rs/src/document.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 /// Open content is useful for modeling unstructured data that has no schema, data that can't be
 /// modeled using rigid types, or data that has a schema that evolves outside of the purview of a model.
 /// The serialization format of a document is an implementation detail of a protocol.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub enum Document {
     /// object
     // n(0)
@@ -30,13 +30,8 @@ pub enum Document {
     Bool(bool),
     /// null
     // n(6)
+    #[default]
     Null,
-}
-
-impl Default for Document {
-    fn default() -> Self {
-        Document::Null
-    }
 }
 
 /// Borrowed Document Type
@@ -45,7 +40,7 @@ impl Default for Document {
 /// Open content is useful for modeling unstructured data that has no schema, data that can't be
 /// modeled using rigid types, or data that has a schema that evolves outside of the purview of a model.
 /// The serialization format of a document is an implementation detail of a protocol.
-#[derive(Clone, Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub enum DocumentRef<'v> {
     /// object
     // n(0)
@@ -67,13 +62,8 @@ pub enum DocumentRef<'v> {
     Bool(bool),
     /// null
     // n(6)
+    #[default]
     Null,
-}
-
-impl Default for DocumentRef<'_> {
-    fn default() -> Self {
-        DocumentRef::Null
-    }
 }
 
 impl<'v> DocumentRef<'v> {
@@ -728,9 +718,9 @@ where
 }
 /// Encode DocumentRef as cbor
 #[doc(hidden)]
-pub fn encode_document_ref<'v, W: crate::cbor::Write>(
+pub fn encode_document_ref<W: crate::cbor::Write>(
     e: &mut crate::cbor::Encoder<W>,
-    val: &DocumentRef<'v>,
+    val: &DocumentRef<'_>,
 ) -> RpcResult<()>
 where
     <W as crate::cbor::Write>::Error: std::fmt::Display,

--- a/rpc-rs/src/provider.rs
+++ b/rpc-rs/src/provider.rs
@@ -199,6 +199,19 @@ impl HostBridge {
     pub fn lattice_prefix(&self) -> &str {
         &self.host_data.lattice_rpc_prefix
     }
+
+    /// Deserializes HostData config_json into T
+    /// (if you just need generic json, use Returns the config_json,
+    /// ```
+    /// // Example: deserialize to a hashmap
+    /// let config = host_bridge.config_json::<HashMap<String,String>>()?;
+    /// ```    
+    pub fn config_json<T: DeserializeOwned>(&self) -> Option<RpcResult<T>> {
+        self.host_data.config_json.as_ref().map(|json| {
+            serde_json::from_str::<T>(json.as_str())
+                .map_err(|e| RpcError::Deser(format!("deserializing config_json: {e}")))
+        })
+    }
 }
 
 impl Deref for HostBridge {

--- a/rpc-rs/src/provider.rs
+++ b/rpc-rs/src/provider.rs
@@ -199,14 +199,16 @@ impl HostBridge {
     }
 
     /// Returns the configuration values as a json string.
-    /// Caller may need to deserialize
+    /// Caller may need to deserialize, and may want to cache the results
+    /// if the data is large or this method is called frequently.
+    /// If there is no configuration defined, returns None.
     /// ```no_run
     /// # #[tokio::main]
     /// # async fn main() {
     /// # use std::collections::HashMap;
     /// # let host_bridge = wasmbus_rpc::provider::HostBridge::new_client(async_nats::connect("demo.nats.io").await.unwrap(), &wasmbus_rpc::core::HostData::default()).unwrap();
     /// // Example: deserialize to a hashmap
-    /// let settings: HashMap<String,String>  = if let Some(json) = host_bridge.config_json() {
+    /// let settings: HashMap<String,String>  = if let Some(json) = host_bridge.config_json_raw() {
     ///    serde_json::from_str(&json).unwrap() // handle error
     /// } else {
     ///    Default::default()
@@ -214,8 +216,8 @@ impl HostBridge {
     /// println!("config: {:?}", &settings);
     /// # }
     /// ```    
-    pub fn config_json(&self) -> Option<String> {
-        self.host_data.config_json.clone()
+    pub fn config_json_raw(&self) -> Option<&str> {
+        self.host_data.config_json.as_deref()
     }
 }
 

--- a/rpc-rs/src/provider.rs
+++ b/rpc-rs/src/provider.rs
@@ -198,22 +198,24 @@ impl HostBridge {
         &self.host_data.lattice_rpc_prefix
     }
 
-    /// Deserializes HostData config_json into T
-    /// (if you just need generic json, use Returns the config_json,
+    /// Returns the configuration values as a json string.
+    /// Caller may need to deserialize
     /// ```no_run
     /// # #[tokio::main]
     /// # async fn main() {
     /// # use std::collections::HashMap;
     /// # let host_bridge = wasmbus_rpc::provider::HostBridge::new_client(async_nats::connect("demo.nats.io").await.unwrap(), &wasmbus_rpc::core::HostData::default()).unwrap();
     /// // Example: deserialize to a hashmap
-    /// let config = host_bridge.config_json::<HashMap<String,String>>().unwrap();
+    /// let settings: HashMap<String,String>  = if let Some(json) = host_bridge.config_json() {
+    ///    serde_json::from_str(&json).unwrap() // handle error
+    /// } else {
+    ///    Default::default()
+    /// };
+    /// println!("config: {:?}", &settings);
     /// # }
     /// ```    
-    pub fn config_json<T: DeserializeOwned>(&self) -> Option<RpcResult<T>> {
-        self.host_data.config_json.as_ref().map(|json| {
-            serde_json::from_str::<T>(json.as_str())
-                .map_err(|e| RpcError::Deser(format!("deserializing config_json: {e}")))
-        })
+    pub fn config_json(&self) -> Option<String> {
+        self.host_data.config_json.clone()
     }
 }
 

--- a/rpc-rs/src/provider.rs
+++ b/rpc-rs/src/provider.rs
@@ -151,10 +151,8 @@ pub struct HostBridge {
 }
 
 impl HostBridge {
-    pub(crate) fn new_client(
-        nats: async_nats::Client,
-        host_data: &HostData,
-    ) -> RpcResult<HostBridge> {
+    #[doc(hidden)]
+    pub fn new_client(nats: async_nats::Client, host_data: &HostData) -> RpcResult<HostBridge> {
         let key = Arc::new(if host_data.is_test() {
             KeyPair::new_user()
         } else {
@@ -202,9 +200,14 @@ impl HostBridge {
 
     /// Deserializes HostData config_json into T
     /// (if you just need generic json, use Returns the config_json,
-    /// ```
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// # use std::collections::HashMap;
+    /// # let host_bridge = wasmbus_rpc::provider::HostBridge::new_client(async_nats::connect("demo.nats.io").await.unwrap(), &wasmbus_rpc::core::HostData::default()).unwrap();
     /// // Example: deserialize to a hashmap
-    /// let config = host_bridge.config_json::<HashMap<String,String>>()?;
+    /// let config = host_bridge.config_json::<HashMap<String,String>>().unwrap();
+    /// # }
     /// ```    
     pub fn config_json<T: DeserializeOwned>(&self) -> Option<RpcResult<T>> {
         self.host_data.config_json.as_ref().map(|json| {

--- a/rpc-rs/src/rpc_client.rs
+++ b/rpc-rs/src/rpc_client.rs
@@ -158,7 +158,7 @@ impl RpcClient {
     }
 
     /// Send an rpc message using json-encoded data
-    pub async fn send_json<Target, Arg, Resp>(
+    pub async fn send_json<Target, Resp>(
         &self,
         origin: WasmCloudEntity,
         target: Target,
@@ -167,7 +167,6 @@ impl RpcClient {
         data: JsonValue,
     ) -> RpcResult<JsonValue>
     where
-        Arg: DeserializeOwned + Serialize,
         Resp: DeserializeOwned + Serialize,
         Target: Into<WasmCloudEntity>,
     {


### PR DESCRIPTION
# Feature or Problem
The `config_json` field from host_data was not accessible to providers through current apis. This change makes it available.

# Consumer Impact
Does not affect existing code
