### PR TITLE
refactor: avoid reliance on async_nats during tracing

### DIFF
--- a/rpc-rs/src/provider.rs
+++ b/rpc-rs/src/provider.rs
@@ -404,7 +404,10 @@ impl HostBridge {
                         );
                         tokio::spawn( async move {
                             #[cfg(feature = "otel")]
-                            crate::otel::attach_span_context(&msg);
+                            crate::otel::attach_span_context(
+                                &msg.headers.as_ref().and_then(|h| h.get(crate::otel::HEADER_TRACEPARENT)).map(|v| v.as_str()),
+                                &msg.headers.as_ref().and_then(|h| h.get(crate::otel::HEADER_TRACESTATE)).map(|v| v.as_str()),
+                            );
                             match crate::common::deserialize::<Invocation>(&msg.payload) {
                                 Ok(inv) => {
                                     let current = tracing::Span::current();


### PR DESCRIPTION
## Feature or Problem

This PR allows the *caller* to determine the type of the input to `attach_span_context` via an `impl Trait`. 

As long as the type that is passed in is able to build a string reference-filled header map (`Hashmap<&str, &str>`) rather than a concrete `async_nats::header::HeaderMap`, it can be used.

This enables projects that use different versions of `nats` to both use `wasmbus-rpc`.

**NOTE** this only *partially* solves the issue, `Injector` also needs to be modified to not rely on `async_nats` (this comes up if you try to use the NATS messaging provider).

### (202/04/04) Refactor: Use `traceparent` and `tracestate` directly

## Related Issues

## Release Information

`next`

## Consumer Impact

Consumers can tinker with a more flexible `wasmbus-rpc`

## Testing

Built on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows


Tested on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)

None added

### Acceptance or Integration

None added

### Manual Verification

Compiled locally