### PR TITLE
bump async-nats to v0.29

### DIFF
--- a/rpc-rs/Cargo.toml
+++ b/rpc-rs/Cargo.toml
@@ -46,7 +46,7 @@ num-bigint = { version = "0.4", optional = true }
 bigdecimal = { version = "0.3", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-async-nats = "0.27.1"
+async-nats = "0.29"
 atty = "0.2"
 data-encoding = "2.3"
 futures = "0.3"


### PR DESCRIPTION
## Feature or Problem
Forgot to commit this as part of https://github.com/wasmCloud/weld/pull/148, but have already tested with this change

