### PR TITLE
Improve error message if format executable was not found

### DIFF
--- a/codegen/src/format.rs
+++ b/codegen/src/format.rs
@@ -23,7 +23,9 @@ pub(crate) fn run_command(program: &str, args: &[&str]) -> Result<()> {
     let mut child = std::process::Command::new(program)
         .args(args.iter())
         .spawn()
-        .map_err(|e| Error::Formatter(format!("failed to start format program \"{program}\": {e}")))?;
+        .map_err(|e| {
+            Error::Formatter(format!("failed to start format program \"{program}\": {e}"))
+        })?;
 
     let code = child
         .wait()

--- a/codegen/src/format.rs
+++ b/codegen/src/format.rs
@@ -23,7 +23,7 @@ pub(crate) fn run_command(program: &str, args: &[&str]) -> Result<()> {
     let mut child = std::process::Command::new(program)
         .args(args.iter())
         .spawn()
-        .map_err(|e| Error::Formatter(format!("failed to start: {e}")))?;
+        .map_err(|e| Error::Formatter(format!("failed to start format program \"{program}\": {e}")))?;
 
     let code = child
         .wait()


### PR DESCRIPTION
## Feature or Problem
Cryptic error message if formatter program is not in the PATH (reported by user on slack)
```
failed to start: No such file or directory (os error 2)
```

After the change:
```
source formatter failed to start format program "rustfmt": No such file or directory (os error 2)
```

## Testing
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [x] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [x] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Manual Verification
built with and without rustfmt in path to verify error


# Next steps

fully deploying this change requires bumping the weld/codegen crate version and bumping that version inside wash-lib